### PR TITLE
Rewrite README as a brief overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Functional Programming in Go [![Actions Status](https://github.com/BooleanCat/go-functional/workflows/test/badge.svg)](https://github.com/BooleanCat/go-functional/actions)
+# Functional Programming in Go [![Actions Status](https://github.com/BooleanCat/go-functional/workflows/test/badge.svg)](https://github.com/BooleanCat/go-functional/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/BooleanCat/go-functional.svg)](https://pkg.go.dev/github.com/BooleanCat/go-functional)
 
 A general purpose library offering functional tooling for Golang.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Functional Programming in Go
+# Functional Programming in Go [![Actions Status](https://github.com/BooleanCat/go-functional/workflows/test/badge.svg)](https://github.com/BooleanCat/go-functional/actions)
 
 A general purpose library offering functional tooling for Golang.
 

--- a/README.md
+++ b/README.md
@@ -1,55 +1,67 @@
 # Functional Programming in Go [![Actions Status](https://github.com/BooleanCat/go-functional/workflows/test/badge.svg)](https://github.com/BooleanCat/go-functional/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/BooleanCat/go-functional.svg)](https://pkg.go.dev/github.com/BooleanCat/go-functional)
 
-A general purpose library offering functional tooling for Golang.
+A general purpose library offering functional helpers for Golang.
 
-## What do you mean?
+_*Note: this library required Go 1.18, which is currently in beta.*_
 
 ```go
-isEven := func(a int) bool { return a%2 == 0 }
-evens := iter.Take[int[(iter.Filter[int](iter.Count(), isEven), 3)
-assert.SliceEqual(t, iter.Collect[int](evens), []int{0, 2, 4})
+// Find the first 5 prime numbers
+primes := iter.Take[int[(iter.Filter[int](iter.Count(), isPrime), 5)
+assert.SliceEqual(t, iter.Collect[int](primes), []int{2, 3, 5, 7, 11})
 ```
 
-## Not intended for production use (yet?)
+_[Read the docs.](https://pkg.go.dev/github.com/BooleanCat/go-functional)_
 
-This library was written to demonstrate what is possible using generics in the
-realm of functional programming in Go.
+## Core concepts
 
-I've yet to formalise many things about the rules and types offered by this
+This library introduces two core concepts, the `Iterator` and the `Option`.
+Using these two concepts this library derives many pre-defined iterators for
+use.
+
+### The `Option`
+
+The `Option` is simply a type that represents the presence or absence of a
+value. Options behave somewhat like enumerations with two variants:
+`Some(value)` and `None`.
+
+### The `Iterator`
+
+```go
+type Iterator[T any] interface {
+	Next() option.Option[T]
+}
+```
+
+The `Iterator` is an interface that defines the behaviour of some type that
+"yields" values. Each call to `Next()` on an `Iterator` will yield another
+value as defined by that specific `Iterator`. For example, the iterator
+`iter.Count()` yields 0, 1, 2, 3, etc. and onwards to infinity (or the integer
+limit!).
+
+Iterators will yield `Some(value)` for as long as they have values to yield.
+Iterators that have exhausted all their values will then always yield `None`.
+
+This library defines many iterators and a few are demonstrated below. For the
+entire set simply visit the
+[package documentation](https://pkg.go.dev/github.com/BooleanCat/go-functional/iter).
+
+### Iterator showcase
+
+Here are a few trivial example of what's possible using the iterators in this
 library.
 
-## The Iterator
-
-The core idea of this library is the Iterator. It's an interface that describes
-type associated with a single receiver: `Next() option.Option[T]`. Simply put,
-calling `Next()` will yield the next value from an iterator. This library
-implements a fair number of common Iterators such as `Map`, `Filter`, `Count`
-and more described in the documentation below.
-
-To use an example to demonstrate how Iterators can be powerfully combined,
-here's how you'd use a Filter and an infinite Counter to generate every
-possible prime number:
-
 ```go
-primes := iter.Filter[int](iter.Count(), isPrime)
+// All even natural numbers (2, 4, 6, 8...)
+isEven := func(n int) bool { return n%2 == 0 }
+evens := iter.Filter[int](iter.Drop[int](iter.Count(), 1), isEven)
 ```
 
-## Options and Results
+```go
+// All non-empty lines from a file
+lines := iter.Exclude[string](iter.LinesString(file), filters.IsZero[string])
+```
 
-Two core types were implemented for this package: `Option[T]` and `Result[T]`.
-
-Options represent the presence or absence of a value and come in two flavours:
-`Some(value)` and `None`. Iterators yield `Some` variants until they are
-exhuasted and then they yield `None` variants. For example, an iterator
-yielding the first three naturals numbers would yield `Some(1)`, `Some(2)`,
-`Some(3)` and `None` on subsequent calls to `Next()`.
-
-Results represent success or failure and are likewise represented by two
-variants: `Ok(value)` and `Err(error)`.
-
-## To Do
-
-- Write a better README
-- Learn how to use go doc and generate docs
-- Write some Example specs for auto-docs
-- Formalise iterator rules for things like repeated calls and chain-call rules
+```go
+// String representations of numbers
+numbers := iter.Map[int, string](iter.Count(), strconv.Itoa)
+```


### PR DESCRIPTION
Core concepts for Iterators are communicated in the main README leaving all other docs to the reference docs (which will be overhauled separately.