### PR TITLE
Add FromPredicate to Option

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -19,6 +19,17 @@ func None[T any]() Option[T] {
 	return Option[T]{}
 }
 
+// FromPredicate returns a smart constructor based on the given predicate.
+func FromPredicate[T any](predicate func(value T) bool) func(value T) Option[T] {
+	return func(value T) Option[T] {
+		if predicate(value) {
+			return Some(value)
+		} else {
+			return None[T]()
+		}
+	}
+}
+
 func (o Option[T]) String() string {
 	if o.present {
 		return fmt.Sprintf("Some(%v)", o.value)

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -63,6 +63,20 @@ func ExampleOption_IsNone() {
 }
 
 func ExampleOption_Value() {
+	isEven := func(a int) bool { return a%2 == 0 }
+	constructor := option.FromPredicate(isEven)
+	none := constructor(1)
+	some := constructor(2)
+
+	fmt.Println(none)
+	fmt.Println(some)
+
+	// Output:
+	// None
+	// Some(2)
+}
+
+func ExampleFromPredicate() {
 	value, ok := option.Some(4).Value()
 	fmt.Println(value)
 	fmt.Println(ok)


### PR DESCRIPTION
**Please provide a brief description of the change.**

`FromPredicate` is a handy function when working with iterators, when you want to map to options, for example:

```go
isEven := func(a int) bool { return a%2 == 0 }
c := option.FromPredicate(isEven)
c(1) // None 
c(2) // Some(2)
```

**Which issue does this change relate to?**

No issue.

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [X] I have read and understood the CONTRIBUTING guidelines
- [ ] My code is formatted (`make check`) - dunno, `gofmt` on my terminal falls over due to generics I think, but VSCode was fine.
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies