### PR TITLE
Add FilterMap iterator

### DIFF
--- a/iter/filter_map.go
+++ b/iter/filter_map.go
@@ -1,0 +1,34 @@
+package iter
+
+import (
+	"github.com/BooleanCat/go-functional/option"
+)
+
+// FilterMapIter implements `FilterMap`. See `FilterMap`'s documentation.
+type FilterMapIter[T any, U any] struct {
+	iter Iterator[T]
+	fun  func(T) option.Option[U]
+}
+
+// FilterMap instantiates a `FilterMapIter` that selectively yields the inner value of `Some` variants
+// from the provided function. See `Option`s documentation..
+func FilterMap[T any, U any](iter Iterator[T], fun func(T) option.Option[U]) *FilterMapIter[T, U] {
+	return &FilterMapIter[T, U]{iter, fun}
+}
+
+// Next implements the Iterator interface for `FilterMap`.
+func (iter *FilterMapIter[T, U]) Next() option.Option[U] {
+	for {
+		value, ok := iter.iter.Next().Value()
+		if !ok {
+			return option.None[U]()
+		}
+
+		opt := iter.fun(value)
+		if opt.IsSome() {
+			return opt
+		}
+	}
+}
+
+var _ Iterator[struct{}] = new(FilterMapIter[struct{}, struct{}])

--- a/iter/filter_map_test.go
+++ b/iter/filter_map_test.go
@@ -1,0 +1,50 @@
+package iter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/BooleanCat/go-functional/internal/assert"
+	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/option"
+)
+
+func ExampleFilterMap() {
+	lengthIfGTFive := func(s string) option.Option[int] {
+		if len(s) > 5 {
+			return option.Some(len(s))
+		} else {
+			return option.None[int]()
+		}
+	}
+	filtered := iter.FilterMap[string](iter.Lift([]string{"foo", "axolotl", "bort", "cowabunga"}), lengthIfGTFive)
+	fmt.Println(filtered.Next())
+	fmt.Println(filtered.Next())
+	fmt.Println(filtered.Next())
+
+	// Output:
+	// Some(7)
+	// Some(9)
+	// None
+}
+
+func TestFilterMap(t *testing.T) {
+	lookupAge := func(name string) option.Option[int] {
+		if name == "william" {
+			return option.Some(32)
+		} else if name == "methuselah" {
+			return option.Some(969)
+		} else {
+			return option.None[int]()
+		}
+	}
+	ages := iter.FilterMap[string](iter.Lift([]string{"william", "bort", "methuselah"}), lookupAge)
+	assert.Equal(t, ages.Next().Unwrap(), 32)
+	assert.Equal(t, ages.Next().Unwrap(), 969)
+}
+
+func TestFilterMapEmpty(t *testing.T) {
+	isEven := func(a int) bool { return a%2 == 0 }
+	evens := iter.FilterMap[int](iter.Exhausted[int](), option.FromPredicate(isEven))
+	assert.True(t, evens.Next().IsNone())
+}

--- a/option/option.go
+++ b/option/option.go
@@ -19,6 +19,17 @@ func None[T any]() Option[T] {
 	return Option[T]{}
 }
 
+// FromPredicate returns a smart constructor based on the given predicate.
+func FromPredicate[T any](predicate func(value T) bool) func(value T) Option[T] {
+	return func(value T) Option[T] {
+		if predicate(value) {
+			return Some(value)
+		} else {
+			return None[T]()
+		}
+	}
+}
+
 func (o Option[T]) String() string {
 	if o.present {
 		return fmt.Sprintf("Some(%v)", o.value)

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -63,6 +63,20 @@ func ExampleOption_IsNone() {
 }
 
 func ExampleOption_Value() {
+	isEven := func(a int) bool { return a%2 == 0 }
+	constructor := option.FromPredicate(isEven)
+	none := constructor(1)
+	some := constructor(2)
+
+	fmt.Println(none)
+	fmt.Println(some)
+
+	// Output:
+	// None
+	// Some(2)
+}
+
+func ExampleFromPredicate() {
 	value, ok := option.Some(4).Value()
 	fmt.Println(value)
 	fmt.Println(ok)


### PR DESCRIPTION
**Please provide a brief description of the change.**

`FilterMap` is a handy iterator when you want to both map and remove items in one expression. For example, consider a lookup that may return `None` or `Some` of the keyed value.

```go
func TestFilterMap(t *testing.T) {
	lookupAge := func(name string) option.Option[int] {
		if name == "william" {
			return option.Some(32)
		} else if name == "methuselah" {
			return option.Some(969)
		} else {
			return option.None[int]()
		}
	}
	ages := iter.FilterMap[string](iter.Lift([]string{"william", "bort", "methuselah"}), lookupAge)
	assert.Equal(t, ages.Next().Unwrap(), 32)
	assert.Equal(t, ages.Next().Unwrap(), 969)
}
```

**Which issue does this change relate to?**

No issue.

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [X] I have read and understood the CONTRIBUTING guidelines
- [ ] My code is formatted (`make check`) - dunno, `gofmt` on my terminal falls over due to generics I think, but VSCode was fine.
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies

Note that this is dependent on `option.FromPredicate` just for convenience sake. Not required.