### PR TITLE
Add some functions that performs built-in binary operators

### DIFF
--- a/iter/ops/binary.go
+++ b/iter/ops/binary.go
@@ -1,0 +1,30 @@
+package ops
+
+import (
+	"github.com/BooleanCat/go-functional/constraints"
+)
+
+// Add performs the `+` operation for the two inputs, returning the result.
+func Add[T constraints.Integer | constraints.Float | ~string](a, b T) T {
+	return a + b
+}
+
+// Multiply performs the `*` operation for the two inputs, returning the result.
+func Multiply[T constraints.Integer | constraints.Float](a, b T) T {
+	return a * b
+}
+
+// BitwiseAnd performs the `&` operation for the two inputs, returning the result.
+func BitwiseAnd[T constraints.Integer](a, b T) T {
+	return a & b
+}
+
+// BitwiseOr performs the `|` operation for the two inputs, returning the result.
+func BitwiseOr[T constraints.Integer](a, b T) T {
+	return a | b
+}
+
+// BitwiseXor performs the `^` operation for the two inputs, returning the result.
+func BitwiseXor[T constraints.Integer](a, b T) T {
+	return a ^ b
+}

--- a/iter/ops/binary_test.go
+++ b/iter/ops/binary_test.go
@@ -1,0 +1,65 @@
+package ops_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/BooleanCat/go-functional/internal/assert"
+	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/iter/ops"
+)
+
+func ExampleAdd() {
+	total := iter.Fold[int](iter.Lift([]int{1, 2, 3}), 0, ops.Add[int])
+
+	fmt.Println(total)
+	// Output: 6
+}
+
+func ExampleMultiply() {
+	product := iter.Fold[int](iter.Lift([]int{3, 4, 5}), 2, ops.Multiply[int])
+
+	fmt.Println(product)
+	// Output: 120
+}
+
+func ExampleBitwiseAnd() {
+	overlap := iter.Fold[int](iter.Lift([]int{5, 7, 13}), -1, ops.BitwiseAnd[int])
+
+	fmt.Println(overlap)
+	// Output: 5
+}
+
+func ExampleBitwiseOr() {
+	union := iter.Fold[int](iter.Lift([]int{1, 2, 6}), 0, ops.BitwiseOr[int])
+
+	fmt.Println(union)
+	// Output: 7
+}
+
+func ExampleBitwiseXor() {
+	result := iter.Fold[int](iter.Lift([]int{1, 2, 6}), 0, ops.BitwiseXor[int])
+
+	fmt.Println(result)
+	// Output: 5
+}
+
+func TestAdd(t *testing.T) {
+	assert.Equal(t, ops.Add(5, 6), 11)
+}
+
+func TestMultiply(t *testing.T) {
+	assert.Equal(t, ops.Multiply(3, 8), 24)
+}
+
+func TestBitwiseAnd(t *testing.T) {
+	assert.Equal(t, ops.BitwiseAnd(6, 10), 2)
+}
+
+func TestBitwiseOr(t *testing.T) {
+	assert.Equal(t, ops.BitwiseOr(6, 10), 14)
+}
+
+func TestBitwiseXor(t *testing.T) {
+	assert.Equal(t, ops.BitwiseXor(5, 6), 3)
+}

--- a/iter/ops/unary.go
+++ b/iter/ops/unary.go
@@ -1,7 +1,6 @@
 package ops
 
 import (
-	"github.com/BooleanCat/go-functional/constraints"
 	"github.com/BooleanCat/go-functional/option"
 	"github.com/BooleanCat/go-functional/result"
 )
@@ -16,9 +15,4 @@ func UnwrapOption[T any](o option.Option[T]) T {
 // all results in an iterator.
 func UnwrapResult[T any](r result.Result[T]) T {
 	return r.Unwrap()
-}
-
-// Add performs the `+` operation for the two inputs, returning the result.
-func Add[T constraints.Integer | constraints.Float | ~string](a, b T) T {
-	return a + b
 }

--- a/iter/ops/unary_test.go
+++ b/iter/ops/unary_test.go
@@ -12,13 +12,6 @@ import (
 	"github.com/BooleanCat/go-functional/result"
 )
 
-func ExampleAdd() {
-	total := iter.Fold[int](iter.Lift([]int{1, 2, 3}), 0, ops.Add[int])
-
-	fmt.Println(total)
-	// Output: 6
-}
-
 func ExampleUnwrapOption() {
 	options := iter.Lift([]option.Option[int]{
 		option.Some(4),
@@ -101,8 +94,4 @@ func TestUnwrapResultPanic(t *testing.T) {
 	)
 
 	t.Error("did not panic")
-}
-
-func TestAdd(t *testing.T) {
-	assert.Equal(t, ops.Add(5, 6), 11)
 }


### PR DESCRIPTION
**Please provide a brief description of the change.**

Add some functions that performs built-in binary operators

**Which issue does this change relate to?**

Resolves #22

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
    - NOTE: [580efcf](https://github.com/BooleanCat/go-functional/pull/30/commits/580efcf89bb57f85f83b703506c103eb7d087579) adds multiple trivial functions. It might violate "single change". I will split commit if you want.
- [x] I have added relevant tests
- [x] I have not added any dependencies

**Additional context**

I split `ops.go` into `unary.go` and `binary.go`.
I'll revert it or split it under another rule.

I haven't renamed `Add` by `Sum` as suggested in #22 .
I have a justification for it: `sum(x) = fold(x, 0, +)` and `add(x, y) = x + y` rather than `sum(x, y) = x + y)`
Regardless the reason above, I'm OK to rename it if you want.
`Product` vs `Multiply` is same as above.