### PR TITLE
Channel iterator

### DIFF
--- a/iter/channel.go
+++ b/iter/channel.go
@@ -1,0 +1,26 @@
+package iter
+
+import "github.com/BooleanCat/go-functional/option"
+
+// ChannelIter implements `FromChannel`. See `FromChannel`'s documentation.
+type ChannelIter[T any] struct {
+	item chan T
+}
+
+// FromChannel instantiates a `ChannelIter` that will yield each value from the provided channel.
+func FromChannel[T any](ch chan T) *ChannelIter[T] {
+	return &ChannelIter[T]{ch}
+}
+
+// Next implements the Iterator interface for `ChannelIter`.
+func (iter *ChannelIter[T]) Next() option.Option[T] {
+
+	value, ok := <-iter.item
+	if !ok {
+		return option.None[T]()
+	}
+
+	return option.Some(value)
+}
+
+var _ Iterator[struct{}] = new(ChannelIter[struct{}])

--- a/iter/channel_test.go
+++ b/iter/channel_test.go
@@ -1,0 +1,45 @@
+package iter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/BooleanCat/go-functional/internal/assert"
+	"github.com/BooleanCat/go-functional/iter"
+)
+
+func ExampleFromChannel() {
+	ch := make(chan int, 2)
+
+	go func() {
+		ch <- 1
+		ch <- 2
+		close(ch)
+	}()
+
+	fmt.Println(iter.Collect[int](iter.FromChannel[int](ch)))
+
+	// Output: [1 2]
+}
+
+func TestFromchannel(t *testing.T) {
+	ch := make(chan int)
+
+	go func() {
+		ch <- 1
+		ch <- 2
+		ch <- 3
+		close(ch)
+	}()
+
+	assert.Equal(t, iter.FromChannel[int](ch).Next().Unwrap(), 1)
+	assert.Equal(t, iter.FromChannel[int](ch).Next().Unwrap(), 2)
+	assert.Equal(t, iter.FromChannel[int](ch).Next().Unwrap(), 3)
+	assert.True(t, iter.FromChannel[int](ch).Next().IsNone())
+}
+
+func TestFromChannelEmpty(t *testing.T) {
+	ch := make(chan int)
+	close(ch)
+	assert.True(t, iter.FromChannel[int](ch).Next().IsNone())
+}


### PR DESCRIPTION
Add FromChannel iterator.

An iterator that plugs consumes a channel. The iterator is exhausted when the channel is closed.

[issue #29](https://github.com/BooleanCat/go-functional/issues/29)

**Contribution checklist.**

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] My code is formatted (`make check`)
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies

**Additional context**

_Add any other context about the problem here._
