### PR TITLE
Find iter members from predicate

### DIFF
--- a/iter/find.go
+++ b/iter/find.go
@@ -1,0 +1,18 @@
+package iter
+
+import "github.com/BooleanCat/go-functional/option"
+
+// Find searches for the first occurance of a value that satisfies the
+// predicate and returns that value. If no value satisfies the predicate, it
+// returns `None`.
+func Find[T any](iter Iterator[T], predicate func(v T) bool) option.Option[T] {
+	for {
+		if value, ok := iter.Next().Value(); ok {
+			if predicate(value) {
+				return option.Some(value)
+			}
+		} else {
+			return option.None[T]()
+		}
+	}
+}

--- a/iter/find_test.go
+++ b/iter/find_test.go
@@ -1,0 +1,33 @@
+package iter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/BooleanCat/go-functional/internal/assert"
+	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/option"
+)
+
+func ExampleFind() {
+	values := iter.Lift([]string{"foo", "bar", "baz"})
+	bar := iter.Find[string](values, func(v string) bool { return v == "bar" })
+
+	fmt.Println(bar)
+	// Output: Some(bar)
+}
+
+func TestFind(t *testing.T) {
+	values := iter.Lift([]string{"foo", "bar", "baz"})
+	bar := iter.Find[string](values, func(v string) bool { return v == "bar" })
+
+	assert.Equal(t, bar, option.Some("bar"))
+	assert.Equal(t, values.Next().Unwrap(), "baz")
+}
+
+func TestFindEmpty(t *testing.T) {
+	values := iter.Exhausted[int]()
+	found := iter.Find[int](values, func(v int) bool { return v == 0 })
+
+	assert.True(t, found.IsNone())
+}


### PR DESCRIPTION
**Please provide a brief description of the change.**

Search an iterator for the first member matching the predicate and return the value.

**Which issue does this change relate to?**

https://github.com/BooleanCat/go-functional/issues/36

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [ ] I have read and understood the CONTRIBUTING guidelines
- [ ] My code is formatted (`make check`)
- [ ] I have run tests (`make test`)
- [ ] All commits in my PR conform to the commit hygiene section
- [ ] I have added relevant tests
- [ ] I have not added any dependencies
