### PR TITLE
Test in CI with latest Go version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
-        with: { go-version: "1.20" }
+        with: { go-version: "1.21" }
       - run: make check
         env: { SKIP_LINT: true }
       - uses: golangci/golangci-lint-action@v3
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go-version: ["1.19", "1.20"]
+        go-version: ["1.20", "1.21"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/iter/find.go
+++ b/iter/find.go
@@ -2,9 +2,8 @@ package iter
 
 import "github.com/BooleanCat/go-functional/option"
 
-// Find searches for the first occurance of a value that satisfies the
-// predicate and returns that value. If no value satisfies the predicate, it
-// returns `None`.
+// Find the first occurance of a value that satisfies the predicate and return
+// that value. If no value satisfies the predicate, return `None`.
 func Find[T any](iter Iterator[T], predicate func(v T) bool) option.Option[T] {
 	for {
 		if value, ok := iter.Next().Value(); ok {


### PR DESCRIPTION
**Please provide a brief description of the change.**

Go 1.21 has shipped, test with that and stop testing end-of-life versions.

**Which issue does this change relate to?**

None

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
