### PR TITLE
Added additional JSON test

### DIFF
--- a/option/json_test.go
+++ b/option/json_test.go
@@ -64,3 +64,10 @@ func TestUnmarshalEmpty(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, value.MiddleName.IsNone())
 }
+
+func TestUnmarshalError(t *testing.T) {
+	var number option.Option[int]
+	err := number.UnmarshalJSON([]byte("not a number"))
+	assert.NotNil(t, err)
+	assert.True(t, number.IsNone())
+}


### PR DESCRIPTION
**Please provide a brief description of the change.**

Added explicit test to force an error when unmarshaling JSON through the Option struct.  

**Which issue does this change relate to?**

It isn't related to an issue, simply a chore to increase coverage on the option/json.go file where reasonably practicable.

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] My code is formatted (`make check`)
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies

**Additional context**

I'm a hobby developer so please have some patience if I've missed something.