### PR TITLE
Add iter.ForEach

### DIFF
--- a/iter/iter.go
+++ b/iter/iter.go
@@ -60,3 +60,14 @@ func ToChannel[T any](iter Iterator[T]) chan T {
 
 	return ch
 }
+
+// ForEach consumes an iterator and executes callback function on each item.
+func ForEach[T any](iter Iterator[T], callback func(T)) {
+	for {
+		if value, ok := iter.Next().Value(); ok {
+			callback(value)
+		} else {
+			break
+		}
+	}
+}

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -70,3 +70,22 @@ func TestToChannelEmpty(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestForEach(t *testing.T) {
+	words := iter.Lift([]string{"foo", "bar", "baz"})
+	sum := ""
+	iter.ForEach[string](words, func(word string) {
+		sum += word
+	})
+	assert.Equal(t, "foobarbaz", sum)
+}
+
+func TestForEachEmpty(t *testing.T) {
+	words := iter.Lift([]string{})
+	sum := ""
+	iter.ForEach[string](words, func(word string) {
+		sum += word
+	})
+
+	assert.Empty[string](t, sum)
+}


### PR DESCRIPTION
**Please provide a brief description of the change.**

A sentence or two is fine, the rest should be clear from the code change and related issue.
It adds for each for iterator package, which can execute a callback on each item contained by an iterator.

**Which issue does this change relate to?**

Please provide a link to the issue that this change resolved.
#45 


If there is no such issue, consider creating one first. Discussions concerning proposed changes ought to take place in an issue and not in pull requests. Pull requests not associated with an issue are less likely to be merged and more likely to ask for changes.

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies

**Additional context**

_Add any other context about the problem here._
