### PR TITLE
Ensure FilterMap returns a concrete type

### DIFF
--- a/iter/filter.go
+++ b/iter/filter.go
@@ -73,6 +73,6 @@ var _ Iterator[struct{}] = new(FilterMapIter[struct{}, struct{}])
 // Accepts an underlying iterator as data source and a filtering + mapping function
 // it allows the user to filter elements by returning a None variant and to transform
 // elements by returning a Some variant.
-func FilterMap[T any, U any](itr Iterator[T], fun func(T) option.Option[U]) Iterator[U] {
+func FilterMap[T any, U any](itr Iterator[T], fun func(T) option.Option[U]) *FilterMapIter[T, U] {
 	return &FilterMapIter[T, U]{itr, fun, false}
 }

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -36,7 +36,7 @@ func ExampleFilterMap() {
 		selectAndTripleOdds,
 	)
 
-	fmt.Println(iter.Collect(triples))
+	fmt.Println(iter.Collect[int](triples))
 
 	// Output: [3 9 15]
 }
@@ -104,7 +104,7 @@ func TestFilterMap(t *testing.T) {
 		iter.Lift([]int{1, 2, 3, 4, 5, 6}),
 		selectEvenAndDouble,
 	)
-	result := iter.Collect(fltMap)
+	result := iter.Collect[int](fltMap)
 
 	assert.SliceEqual(t, result, []int{4, 8, 12})
 }
@@ -123,7 +123,7 @@ func TestFilterMapEmpty(t *testing.T) {
 		selectEvenAndDouble,
 	)
 
-	assert.Empty[int](t, iter.Collect(fltMapEmpty))
+	assert.Empty[int](t, iter.Collect[int](fltMapEmpty))
 }
 
 func TestFilterMapExhausted(t *testing.T) {

--- a/iter/lift.go
+++ b/iter/lift.go
@@ -42,7 +42,10 @@ type LiftHashMapIter[T comparable, U any] struct {
 // LiftHashMap instantiates a `LiftHashMapIter` that will yield all items in
 // the provided map in the form iter.Tuple[key, value].
 //
-// Unlike most iterators, `LiftHashMap` should be closed after usage (because).
+// Unlike most iterators, `LiftHashMap` should be closed after usage (because
+// range order is non-deterministic and the iterator needs to preserve its
+// progress). This restriction may be removed if/when Go has a "yield" keyword.
+//
 // The iterator is closed when any of the two conditions are met.
 //
 // 1. The caller explicitly invokes the `Close` method.


### PR DESCRIPTION
**Please provide a brief description of the change.**

Ensure FilterMap returns a concrete type. It erroneously returns an interface at the moment.

**Which issue does this change relate to?**

None.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
