### PR TITLE
Add collect method to each iter (except Count)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A general purpose library offering functional helpers for Golang.
 
 ```go
 // Find the first 5 prime numbers
-primes := iter.Take(iter.Filter(iter.Count(), isPrime), 5)
-assert.SliceEqual(t, iter.Collect(primes), []int{2, 3, 5, 7, 11})
+primes := iter.Take(iter.Filter(iter.Count(), isPrime), 5).Collect()
+reflect.DeepEqual(t, primes, []int{2, 3, 5, 7, 11})
 ```
 
 _[Read the docs.](https://pkg.go.dev/github.com/BooleanCat/go-functional)_

--- a/iter/chain.go
+++ b/iter/chain.go
@@ -38,3 +38,8 @@ func (iter *ChainIter[T]) Next() option.Option[T] {
 }
 
 var _ Iterator[struct{}] = new(ChainIter[struct{}])
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *ChainIter[T]) Collect() []T {
+	return Collect[T](iter)
+}

--- a/iter/chain_test.go
+++ b/iter/chain_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleChain() {
-	fmt.Println(iter.Collect[int](iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4}), iter.Lift([]int{0, 9}))))
+	fmt.Println(iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4}), iter.Lift([]int{0, 9})).Collect())
 	// Output: [1 2 3 4 0 9]
 }
 
@@ -43,4 +43,9 @@ func TestChainExhausted(t *testing.T) {
 	assert.True(t, iter.Next().IsNone())
 	assert.Equal(t, delegate1.NextCallCount(), 1)
 	assert.Equal(t, delegate2.NextCallCount(), 1)
+}
+
+func TestChainCollect(t *testing.T) {
+	items := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Collect()
+	assert.SliceEqual(t, items, []int{1, 2, 3, 4})
 }

--- a/iter/channel.go
+++ b/iter/channel.go
@@ -24,3 +24,8 @@ func (iter *ChannelIter[T]) Next() option.Option[T] {
 }
 
 var _ Iterator[struct{}] = new(ChannelIter[struct{}])
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *ChannelIter[T]) Collect() []T {
+	return Collect[T](iter)
+}

--- a/iter/channel_test.go
+++ b/iter/channel_test.go
@@ -17,8 +17,7 @@ func ExampleFromChannel() {
 		close(ch)
 	}()
 
-	fmt.Println(iter.Collect[int](iter.FromChannel(ch)))
-
+	fmt.Println(iter.FromChannel(ch).Collect())
 	// Output: [1 2]
 }
 
@@ -32,14 +31,29 @@ func TestFromChannel(t *testing.T) {
 		close(ch)
 	}()
 
-	assert.Equal(t, iter.FromChannel(ch).Next().Unwrap(), 1)
-	assert.Equal(t, iter.FromChannel(ch).Next().Unwrap(), 2)
-	assert.Equal(t, iter.FromChannel(ch).Next().Unwrap(), 3)
-	assert.True(t, iter.FromChannel(ch).Next().IsNone())
+	numbers := iter.FromChannel(ch)
+
+	assert.Equal(t, numbers.Next().Unwrap(), 1)
+	assert.Equal(t, numbers.Next().Unwrap(), 2)
+	assert.Equal(t, numbers.Next().Unwrap(), 3)
+	assert.True(t, numbers.Next().IsNone())
 }
 
 func TestFromChannelEmpty(t *testing.T) {
 	ch := make(chan int)
 	close(ch)
 	assert.True(t, iter.FromChannel(ch).Next().IsNone())
+}
+
+func TestFromChannelCollect(t *testing.T) {
+	ch := make(chan int)
+
+	go func() {
+		ch <- 1
+		ch <- 2
+		close(ch)
+	}()
+
+	numbers := iter.FromChannel(ch).Collect()
+	assert.SliceEqual(t, numbers, []int{1, 2})
 }

--- a/iter/drop.go
+++ b/iter/drop.go
@@ -45,3 +45,8 @@ func (iter *DropIter[T]) delegateNext() option.Option[T] {
 }
 
 var _ Iterator[struct{}] = new(DropIter[struct{}])
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *DropIter[T]) Collect() []T {
+	return Collect[T](iter)
+}

--- a/iter/drop_test.go
+++ b/iter/drop_test.go
@@ -43,3 +43,8 @@ func TestDropExhaustedLater(t *testing.T) {
 	assert.True(t, iterator.Next().IsNone())
 	assert.Equal(t, delegate.NextCallCount(), 3)
 }
+
+func TestDropCollect(t *testing.T) {
+	numbers := iter.Drop[int](iter.Lift([]int{1, 2, 3}), 2).Collect()
+	assert.SliceEqual(t, numbers, []int{3})
+}

--- a/iter/exhausted.go
+++ b/iter/exhausted.go
@@ -17,3 +17,8 @@ func (iter *ExhaustedIter[T]) Next() option.Option[T] {
 }
 
 var _ Iterator[struct{}] = new(ExhaustedIter[struct{}])
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *ExhaustedIter[T]) Collect() []T {
+	return Collect[T](iter)
+}

--- a/iter/exhausted_test.go
+++ b/iter/exhausted_test.go
@@ -16,3 +16,7 @@ func ExampleExhausted() {
 func TestExhausted(t *testing.T) {
 	assert.True(t, iter.Exhausted[int]().Next().IsNone())
 }
+
+func TestExhaustedCollect(t *testing.T) {
+	assert.Empty[int](t, iter.Exhausted[int]().Collect())
+}

--- a/iter/filter.go
+++ b/iter/filter.go
@@ -36,6 +36,11 @@ func (iter *FilterIter[T]) Next() option.Option[T] {
 
 var _ Iterator[struct{}] = new(FilterIter[struct{}])
 
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *FilterIter[T]) Collect() []T {
+	return Collect[T](iter)
+}
+
 // Exclude instantiates a `FilterIter` that selectively yields only results that
 // cause the provided function to return `false`.
 func Exclude[T any](iter Iterator[T], fun func(T) bool) *FilterIter[T] {
@@ -75,4 +80,9 @@ var _ Iterator[struct{}] = new(FilterMapIter[struct{}, struct{}])
 // elements by returning a Some variant.
 func FilterMap[T any, U any](itr Iterator[T], fun func(T) option.Option[U]) *FilterMapIter[T, U] {
 	return &FilterMapIter[T, U]{itr, fun, false}
+}
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *FilterMapIter[T, U]) Collect() []U {
+	return Collect[U](iter)
 }

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -75,6 +75,12 @@ func TestFilterExhausted(t *testing.T) {
 	assert.Equal(t, delegate.NextCallCount(), 1)
 }
 
+func TestFilterCollect(t *testing.T) {
+	isEven := func(a int) bool { return a%2 == 0 }
+	evens := iter.Filter[int](iter.Lift([]int{0, 1, 2, 3}), isEven).Collect()
+	assert.SliceEqual(t, evens, []int{0, 2})
+}
+
 func TestExclude(t *testing.T) {
 	isEven := func(a int) bool { return a%2 == 0 }
 	evens := iter.Exclude[int](iter.Count(), isEven)
@@ -89,6 +95,12 @@ func TestExcludeExhausted(t *testing.T) {
 	assert.True(t, ones.Next().IsNone())
 	assert.True(t, ones.Next().IsNone())
 	assert.Equal(t, delegate.NextCallCount(), 1)
+}
+
+func TestExcludeCollect(t *testing.T) {
+	isEven := func(a int) bool { return a%2 == 0 }
+	odds := iter.Exclude[int](iter.Lift([]int{0, 1, 2, 3}), isEven).Collect()
+	assert.SliceEqual(t, odds, []int{1, 3})
 }
 
 func TestFilterMap(t *testing.T) {
@@ -133,4 +145,21 @@ func TestFilterMapExhausted(t *testing.T) {
 	assert.True(t, ones.Next().IsNone())
 	assert.True(t, ones.Next().IsNone())
 	assert.Equal(t, delegate.NextCallCount(), 1)
+}
+
+func TestFilterMapCollect(t *testing.T) {
+	selectEvenAndDouble := func(x int) option.Option[int] {
+		if x%2 > 0 {
+			return option.None[int]()
+		}
+
+		return option.Some(x * 2)
+	}
+
+	doubles := iter.FilterMap[int](
+		iter.Lift([]int{1, 2, 3, 4, 5, 6}),
+		selectEvenAndDouble,
+	).Collect()
+
+	assert.SliceEqual(t, doubles, []int{4, 8, 12})
 }

--- a/iter/lift.go
+++ b/iter/lift.go
@@ -31,6 +31,11 @@ func (iter *LiftIter[T]) Next() option.Option[T] {
 
 var _ Iterator[struct{}] = new(LiftIter[struct{}])
 
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *LiftIter[T]) Collect() []T {
+	return Collect[T](iter)
+}
+
 // LiftHashMapIter implements `LiftHashMap`. See `LiftHashMap`'s documentation.
 type LiftHashMapIter[T comparable, U any] struct {
 	hashmap  map[T]U
@@ -95,6 +100,11 @@ func (iter *LiftHashMapIter[T, U]) Next() option.Option[Tuple[T, U]] {
 
 var _ Iterator[Tuple[struct{}, struct{}]] = new(LiftHashMapIter[struct{}, struct{}])
 
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *LiftHashMapIter[T, U]) Collect() []Tuple[T, U] {
+	return Collect[Tuple[T, U]](iter)
+}
+
 // LiftHashMapKeysIter implements `LiftHashMapKeys`. See `LiftHashMapKeys`'
 // documentation.
 type LiftHashMapKeysIter[T comparable, U any] struct {
@@ -134,6 +144,11 @@ func (iter *LiftHashMapKeysIter[T, U]) Next() option.Option[T] {
 
 var _ Iterator[struct{}] = new(LiftHashMapKeysIter[struct{}, struct{}])
 
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *LiftHashMapKeysIter[T, U]) Collect() []T {
+	return Collect[T](iter)
+}
+
 // LiftHashMapValuesIter implements `LiftHashMapValues`. See
 // `LiftHashMapValues`' documentation.
 type LiftHashMapValuesIter[T comparable, U any] struct {
@@ -172,3 +187,8 @@ func (iter *LiftHashMapValuesIter[T, U]) Next() option.Option[U] {
 }
 
 var _ Iterator[struct{}] = new(LiftHashMapValuesIter[struct{}, struct{}])
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *LiftHashMapValuesIter[T, U]) Collect() []U {
+	return Collect[U](iter)
+}

--- a/iter/lift_test.go
+++ b/iter/lift_test.go
@@ -12,7 +12,7 @@ import (
 
 func ExampleLift() {
 	positives := iter.Filter[int](iter.Lift([]int{-1, 4, 6, 4, -5}), filters.GreaterThan(-1))
-	fmt.Println(iter.Collect[int](positives))
+	fmt.Println(positives.Collect())
 	// Output: [4 6 4]
 }
 
@@ -25,6 +25,11 @@ func TestLift(t *testing.T) {
 
 func TestLiftEmpty(t *testing.T) {
 	assert.True(t, iter.Lift([]int{}).Next().IsNone())
+}
+
+func TestLiftCollect(t *testing.T) {
+	items := iter.Lift([]int{1, 2}).Collect()
+	assert.SliceEqual(t, items, []int{1, 2})
 }
 
 func TestLiftHashMap(t *testing.T) {
@@ -69,6 +74,19 @@ func TestLiftHashMapCloseAfterExhaustedSafe(t *testing.T) {
 	items := iter.LiftHashMap(pokemon)
 	iter.Collect[iter.Tuple[string, string]](items)
 	items.Close()
+}
+
+func TestLiftHashMapCollect(t *testing.T) {
+	items := iter.LiftHashMap(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	}).Collect()
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].One < items[j].One
+	})
+
+	assert.SliceEqual(t, items, []iter.Tuple[string, string]{{"name", "pikachu"}, {"type", "electric"}})
 }
 
 func TestLiftHashMapKeys(t *testing.T) {
@@ -120,6 +138,17 @@ func TestLiftHashMapKeysCloseAfterExhaustedSafe(t *testing.T) {
 	items.Close()
 }
 
+func TestLiftHashMapKeysCollect(t *testing.T) {
+	keys := iter.LiftHashMapKeys(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	}).Collect()
+
+	sort.Strings(keys)
+
+	assert.SliceEqual(t, keys, []string{"name", "type"})
+}
+
 func TestLiftHashMapValues(t *testing.T) {
 	pokemon := make(map[string]string)
 	pokemon["name"] = "pikachu"
@@ -167,4 +196,15 @@ func TestLiftHashMapValuesCloseAfterExhaustedSafe(t *testing.T) {
 	items := iter.LiftHashMapValues(pokemon)
 	iter.Collect[string](items)
 	items.Close()
+}
+
+func TestLiftHashMapValuesCollect(t *testing.T) {
+	keys := iter.LiftHashMapValues(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	}).Collect()
+
+	sort.Strings(keys)
+
+	assert.SliceEqual(t, keys, []string{"electric", "pikachu"})
 }

--- a/iter/lines.go
+++ b/iter/lines.go
@@ -64,3 +64,8 @@ func LinesString(r io.Reader) *MapIter[result.Result[[]byte], result.Result[stri
 
 	return Map[result.Result[[]byte]](iter, transform)
 }
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *LinesIter) Collect() []result.Result[[]byte] {
+	return Collect[result.Result[[]byte]](iter)
+}

--- a/iter/lines_test.go
+++ b/iter/lines_test.go
@@ -18,7 +18,7 @@ func ExampleLinesString() {
 	lines := iter.LinesString(bytes.NewBufferString("hello\nthere"))
 	unwrapped := iter.Map[result.Result[string]](lines, ops.UnwrapResult[string])
 
-	fmt.Println(iter.Collect[string](unwrapped))
+	fmt.Println(unwrapped.Collect())
 	// Output: [hello there]
 }
 
@@ -26,7 +26,7 @@ func ExampleLines() {
 	lines := iter.Lines(bytes.NewBufferString("hello\nthere"))
 	unwrapped := iter.Map[result.Result[[]byte]](lines, ops.UnwrapResult[[]byte])
 
-	fmt.Println(iter.Collect[[]byte](unwrapped))
+	fmt.Println(unwrapped.Collect())
 	// Output: [[104 101 108 108 111] [116 104 101 114 101]]
 }
 
@@ -78,6 +78,13 @@ func TestLinesFailureLater(t *testing.T) {
 	assert.True(t, lines.Next().Unwrap().IsErr())
 }
 
+func TestLinesCollect(t *testing.T) {
+	items := iter.Lines(bytes.NewBufferString("hello\nthere")).Collect()
+	assert.Equal(t, 2, len(items))
+	assert.SliceEqual(t, items[0].Unwrap(), []byte("hello"))
+	assert.SliceEqual(t, items[1].Unwrap(), []byte("there"))
+}
+
 func TestLinesString(t *testing.T) {
 	file, err := os.Open("fixtures/lines.txt")
 	assert.Nil(t, err)
@@ -126,4 +133,9 @@ func TestLinesStringFailureLater(t *testing.T) {
 	reader.ReadReturns(0, errors.New("oops"))
 
 	assert.True(t, lines.Next().Unwrap().IsErr())
+}
+
+func TestLinesStringCollect(t *testing.T) {
+	items := iter.LinesString(bytes.NewBufferString("hello\nthere")).Collect()
+	assert.SliceEqual(t, items, []result.Result[string]{result.Ok("hello"), result.Ok("there")})
 }

--- a/iter/map.go
+++ b/iter/map.go
@@ -31,3 +31,8 @@ func (iter *MapIter[T, U]) Next() option.Option[U] {
 }
 
 var _ Iterator[struct{}] = new(MapIter[struct{}, struct{}])
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *MapIter[T, U]) Collect() []U {
+	return Collect[U](iter)
+}

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -12,7 +12,7 @@ import (
 
 func ExampleMap() {
 	double := func(a int) int { return a * 2 }
-	items := iter.Collect[int](iter.Map[int](iter.Lift([]int{0, 1, 2, 3}), double))
+	items := iter.Map[int](iter.Lift([]int{0, 1, 2, 3}), double).Collect()
 
 	fmt.Println(items)
 	// Output: [0 2 4 6]
@@ -40,4 +40,10 @@ func TestMapExhausted(t *testing.T) {
 	assert.True(t, iter.Next().IsNone())
 	assert.True(t, iter.Next().IsNone())
 	assert.Equal(t, delegate.NextCallCount(), 1)
+}
+
+func TestMapCollect(t *testing.T) {
+	double := func(a int) int { return a * 2 }
+	items := iter.Map[int, int](iter.Lift([]int{0, 1, 2, 3}), double).Collect()
+	assert.SliceEqual(t, items, []int{0, 2, 4, 6})
 }

--- a/iter/take.go
+++ b/iter/take.go
@@ -31,3 +31,8 @@ func (iter *TakeIter[T]) Next() option.Option[T] {
 }
 
 var _ Iterator[struct{}] = new(TakeIter[struct{}])
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *TakeIter[T]) Collect() []T {
+	return Collect[T](iter)
+}

--- a/iter/take_test.go
+++ b/iter/take_test.go
@@ -40,3 +40,8 @@ func TestTakeExhausted(t *testing.T) {
 	assert.True(t, iter.Next().IsNone())
 	assert.Equal(t, delegate.NextCallCount(), 1)
 }
+
+func TestTakeCollect(t *testing.T) {
+	items := iter.Take[int](iter.Count(), 3).Collect()
+	assert.SliceEqual(t, items, []int{0, 1, 2})
+}

--- a/iter/zip.go
+++ b/iter/zip.go
@@ -33,3 +33,8 @@ func (iter *ZipIter[T, U]) Next() option.Option[Tuple[T, U]] {
 }
 
 var _ Iterator[Tuple[struct{}, struct{}]] = new(ZipIter[struct{}, struct{}])
+
+// Collect is an alternative way of invoking Collect(iter)
+func (iter *ZipIter[T, U]) Collect() []Tuple[T, U] {
+	return Collect[Tuple[T, U]](iter)
+}

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -13,10 +13,7 @@ func ExampleZip() {
 	evens := iter.Filter[int](iter.Count(), isEven)
 	odds := iter.Exclude[int](iter.Count(), isEven)
 
-	zipped := iter.Collect[iter.Tuple[int, int]](
-		iter.Take[iter.Tuple[int, int]](iter.Zip[int, int](evens, odds), 3),
-	)
-	fmt.Println(zipped)
+	fmt.Println(iter.Take[iter.Tuple[int, int]](iter.Zip[int, int](evens, odds), 3).Collect())
 	// Output: [{0 1} {2 3} {4 5}]
 }
 
@@ -50,4 +47,14 @@ func TestZipSecondExhausted(t *testing.T) {
 	zipped := iter.Collect[iter.Tuple[int, int]](iter.Zip[int, int](evens, odds))
 
 	assert.SliceEqual(t, zipped, []iter.Tuple[int, int]{{0, 1}, {2, 3}})
+}
+
+func TestZipCollect(t *testing.T) {
+	isEven := func(a int) bool { return a%2 == 0 }
+	evens := iter.Filter[int](iter.Count(), isEven)
+	odds := iter.Take[int](iter.Exclude[int](iter.Count(), isEven), 2)
+
+	items := iter.Zip[int, int](evens, odds).Collect()
+
+	assert.SliceEqual(t, items, []iter.Tuple[int, int]{{0, 1}, {2, 3}})
 }


### PR DESCRIPTION
**Please provide a brief description of the change.**

Allow iterator collection from method call for more terse code.

**Which issue does this change relate to?**

https://github.com/BooleanCat/go-functional/issues/55

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
