### PR TITLE
Support chaining Drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ library.
 ```go
 // All even natural numbers (2, 4, 6, 8...)
 isEven := func(n int) bool { return n%2 == 0 }
-evens := iter.Filter(iter.Drop(iter.Count(), 1), isEven)
+evens := iter.Filter(iter.Count().Drop(1), isEven)
 ```
 
 ```go

--- a/iter/chain.go
+++ b/iter/chain.go
@@ -36,3 +36,8 @@ var _ Iterator[struct{}] = new(ChainIter[struct{}])
 func (iter *ChainIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *ChainIter[T]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}

--- a/iter/chain_test.go
+++ b/iter/chain_test.go
@@ -49,3 +49,8 @@ func TestChainCollect(t *testing.T) {
 	items := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Collect()
 	assert.SliceEqual(t, items, []int{1, 2, 3, 4})
 }
+
+func TestChainDrop(t *testing.T) {
+	items := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Drop(1).Collect()
+	assert.SliceEqual(t, items, []int{2, 3, 4})
+}

--- a/iter/channel.go
+++ b/iter/channel.go
@@ -29,3 +29,8 @@ var _ Iterator[struct{}] = new(ChannelIter[struct{}])
 func (iter *ChannelIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *ChannelIter[T]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}

--- a/iter/channel_test.go
+++ b/iter/channel_test.go
@@ -57,3 +57,17 @@ func TestFromChannelCollect(t *testing.T) {
 	numbers := iter.FromChannel(ch).Collect()
 	assert.SliceEqual(t, numbers, []int{1, 2})
 }
+
+func TestFromChannelDrop(t *testing.T) {
+	ch := make(chan int)
+
+	go func() {
+		ch <- 1
+		ch <- 2
+		ch <- 3
+		close(ch)
+	}()
+
+	numbers := iter.FromChannel(ch).Drop(1).Collect()
+	assert.SliceEqual(t, numbers, []int{2, 3})
+}

--- a/iter/counter.go
+++ b/iter/counter.go
@@ -21,3 +21,8 @@ func (c *CountIter) Next() option.Option[int] {
 }
 
 var _ Iterator[int] = new(CountIter)
+
+// Drop is an alternative way of invoking Drop(iter)
+func (c *CountIter) Drop(n uint) *DropIter[int] {
+	return Drop[int](c, n)
+}

--- a/iter/counter_test.go
+++ b/iter/counter_test.go
@@ -26,3 +26,8 @@ func TestCount(t *testing.T) {
 	assert.Equal(t, counter.Next().Unwrap(), 1)
 	assert.Equal(t, counter.Next().Unwrap(), 2)
 }
+
+func TestCountDrop(t *testing.T) {
+	counter := iter.Count().Drop(5)
+	assert.Equal(t, counter.Next().Unwrap(), 5)
+}

--- a/iter/cycle.go
+++ b/iter/cycle.go
@@ -48,3 +48,8 @@ func (iter *CycleIter[T]) Next() option.Option[T] {
 }
 
 var _ Iterator[struct{}] = new(CycleIter[struct{}])
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *CycleIter[T]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}

--- a/iter/cycle_test.go
+++ b/iter/cycle_test.go
@@ -38,3 +38,8 @@ func TestCycleExhausted(t *testing.T) {
 	assert.True(t, ones.Next().IsNone())
 	assert.Equal(t, delegate.NextCallCount(), 1)
 }
+
+func TestCycleDrop(t *testing.T) {
+	items := iter.Take[int](iter.Cycle[int](iter.Lift([]int{1, 2})).Drop(1), 5).Collect()
+	assert.SliceEqual(t, items, []int{2, 1, 2, 1, 2})
+}

--- a/iter/drop.go
+++ b/iter/drop.go
@@ -50,3 +50,8 @@ var _ Iterator[struct{}] = new(DropIter[struct{}])
 func (iter *DropIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *DropIter[T]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}

--- a/iter/drop_test.go
+++ b/iter/drop_test.go
@@ -48,3 +48,8 @@ func TestDropCollect(t *testing.T) {
 	numbers := iter.Drop[int](iter.Lift([]int{1, 2, 3}), 2).Collect()
 	assert.SliceEqual(t, numbers, []int{3})
 }
+
+func TestDropDrop(t *testing.T) {
+	counter := iter.Count().Drop(2).Drop(3)
+	assert.Equal(t, counter.Next().Unwrap(), 5)
+}

--- a/iter/exhausted.go
+++ b/iter/exhausted.go
@@ -22,3 +22,8 @@ var _ Iterator[struct{}] = new(ExhaustedIter[struct{}])
 func (iter *ExhaustedIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *ExhaustedIter[T]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}

--- a/iter/exhausted_test.go
+++ b/iter/exhausted_test.go
@@ -20,3 +20,7 @@ func TestExhausted(t *testing.T) {
 func TestExhaustedCollect(t *testing.T) {
 	assert.Empty[int](t, iter.Exhausted[int]().Collect())
 }
+
+func TestExhaustedDrop(t *testing.T) {
+	assert.True(t, iter.Exhausted[int]().Drop(1).Next().IsNone())
+}

--- a/iter/filter.go
+++ b/iter/filter.go
@@ -41,6 +41,11 @@ func (iter *FilterIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *FilterIter[T]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}
+
 // Exclude instantiates a `FilterIter` that selectively yields only results that
 // cause the provided function to return `false`.
 func Exclude[T any](iter Iterator[T], fun func(T) bool) *FilterIter[T] {
@@ -85,4 +90,9 @@ func FilterMap[T any, U any](itr Iterator[T], fun func(T) option.Option[U]) *Fil
 // Collect is an alternative way of invoking Collect(iter)
 func (iter *FilterMapIter[T, U]) Collect() []U {
 	return Collect[U](iter)
+}
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *FilterMapIter[T, U]) Drop(n uint) *DropIter[U] {
+	return Drop[U](iter, n)
 }

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -81,6 +81,12 @@ func TestFilterCollect(t *testing.T) {
 	assert.SliceEqual(t, evens, []int{0, 2})
 }
 
+func TestFilterDrop(t *testing.T) {
+	isEven := func(a int) bool { return a%2 == 0 }
+	evens := iter.Filter[int](iter.Lift([]int{0, 1, 2, 3}), isEven).Drop(1).Collect()
+	assert.SliceEqual(t, evens, []int{2})
+}
+
 func TestExclude(t *testing.T) {
 	isEven := func(a int) bool { return a%2 == 0 }
 	evens := iter.Exclude[int](iter.Count(), isEven)
@@ -101,6 +107,12 @@ func TestExcludeCollect(t *testing.T) {
 	isEven := func(a int) bool { return a%2 == 0 }
 	odds := iter.Exclude[int](iter.Lift([]int{0, 1, 2, 3}), isEven).Collect()
 	assert.SliceEqual(t, odds, []int{1, 3})
+}
+
+func TestExcludeDrop(t *testing.T) {
+	isEven := func(a int) bool { return a%2 == 0 }
+	odds := iter.Exclude[int](iter.Lift([]int{0, 1, 2, 3}), isEven).Drop(1).Collect()
+	assert.SliceEqual(t, odds, []int{3})
 }
 
 func TestFilterMap(t *testing.T) {
@@ -162,4 +174,21 @@ func TestFilterMapCollect(t *testing.T) {
 	).Collect()
 
 	assert.SliceEqual(t, doubles, []int{4, 8, 12})
+}
+
+func TestFilterMapDrop(t *testing.T) {
+	selectEvenAndDouble := func(x int) option.Option[int] {
+		if x%2 > 0 {
+			return option.None[int]()
+		}
+
+		return option.Some(x * 2)
+	}
+
+	doubles := iter.FilterMap[int](
+		iter.Lift([]int{1, 2, 3, 4, 5, 6}),
+		selectEvenAndDouble,
+	).Drop(1).Collect()
+
+	assert.SliceEqual(t, doubles, []int{8, 12})
 }

--- a/iter/lift.go
+++ b/iter/lift.go
@@ -36,6 +36,11 @@ func (iter *LiftIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *LiftIter[T]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}
+
 // LiftHashMapIter implements `LiftHashMap`. See `LiftHashMap`'s documentation.
 type LiftHashMapIter[T comparable, U any] struct {
 	hashmap  map[T]U
@@ -105,6 +110,11 @@ func (iter *LiftHashMapIter[T, U]) Collect() []Tuple[T, U] {
 	return Collect[Tuple[T, U]](iter)
 }
 
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *LiftHashMapIter[T, U]) Drop(n uint) *DropIter[Tuple[T, U]] {
+	return Drop[Tuple[T, U]](iter, n)
+}
+
 // LiftHashMapKeysIter implements `LiftHashMapKeys`. See `LiftHashMapKeys`'
 // documentation.
 type LiftHashMapKeysIter[T comparable, U any] struct {
@@ -149,6 +159,11 @@ func (iter *LiftHashMapKeysIter[T, U]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *LiftHashMapKeysIter[T, U]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}
+
 // LiftHashMapValuesIter implements `LiftHashMapValues`. See
 // `LiftHashMapValues`' documentation.
 type LiftHashMapValuesIter[T comparable, U any] struct {
@@ -191,4 +206,9 @@ var _ Iterator[struct{}] = new(LiftHashMapValuesIter[struct{}, struct{}])
 // Collect is an alternative way of invoking Collect(iter)
 func (iter *LiftHashMapValuesIter[T, U]) Collect() []U {
 	return Collect[U](iter)
+}
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *LiftHashMapValuesIter[T, U]) Drop(n uint) *DropIter[U] {
+	return Drop[U](iter, n)
 }

--- a/iter/lift_test.go
+++ b/iter/lift_test.go
@@ -32,6 +32,11 @@ func TestLiftCollect(t *testing.T) {
 	assert.SliceEqual(t, items, []int{1, 2})
 }
 
+func TestLiftDrop(t *testing.T) {
+	items := iter.Lift([]int{1, 2, 3}).Drop(1).Collect()
+	assert.SliceEqual(t, items, []int{2, 3})
+}
+
 func TestLiftHashMap(t *testing.T) {
 	pokemon := make(map[string]string)
 	pokemon["name"] = "pikachu"
@@ -87,6 +92,16 @@ func TestLiftHashMapCollect(t *testing.T) {
 	})
 
 	assert.SliceEqual(t, items, []iter.Tuple[string, string]{{"name", "pikachu"}, {"type", "electric"}})
+}
+
+func TestLiftHashMapDrop(t *testing.T) {
+	pokemon := make(map[string]string)
+	pokemon["name"] = "pikachu"
+	pokemon["type"] = "electric"
+
+	items := iter.LiftHashMap(pokemon).Drop(1).Collect()
+
+	assert.Equal(t, 1, len(items))
 }
 
 func TestLiftHashMapKeys(t *testing.T) {
@@ -149,6 +164,15 @@ func TestLiftHashMapKeysCollect(t *testing.T) {
 	assert.SliceEqual(t, keys, []string{"name", "type"})
 }
 
+func TestLiftHashMapKeysDrop(t *testing.T) {
+	keys := iter.LiftHashMapKeys(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	}).Drop(1).Collect()
+
+	assert.Equal(t, 1, len(keys))
+}
+
 func TestLiftHashMapValues(t *testing.T) {
 	pokemon := make(map[string]string)
 	pokemon["name"] = "pikachu"
@@ -199,12 +223,21 @@ func TestLiftHashMapValuesCloseAfterExhaustedSafe(t *testing.T) {
 }
 
 func TestLiftHashMapValuesCollect(t *testing.T) {
-	keys := iter.LiftHashMapValues(map[string]string{
+	values := iter.LiftHashMapValues(map[string]string{
 		"name": "pikachu",
 		"type": "electric",
 	}).Collect()
 
-	sort.Strings(keys)
+	sort.Strings(values)
 
-	assert.SliceEqual(t, keys, []string{"electric", "pikachu"})
+	assert.SliceEqual(t, values, []string{"electric", "pikachu"})
+}
+
+func TestLiftHashMapValuesDrop(t *testing.T) {
+	values := iter.LiftHashMapValues(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	}).Drop(1).Collect()
+
+	assert.Equal(t, 1, len(values))
 }

--- a/iter/lines.go
+++ b/iter/lines.go
@@ -69,3 +69,8 @@ func LinesString(r io.Reader) *MapIter[result.Result[[]byte], result.Result[stri
 func (iter *LinesIter) Collect() []result.Result[[]byte] {
 	return Collect[result.Result[[]byte]](iter)
 }
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *LinesIter) Drop(n uint) *DropIter[result.Result[[]byte]] {
+	return Drop[result.Result[[]byte]](iter, n)
+}

--- a/iter/lines_test.go
+++ b/iter/lines_test.go
@@ -85,6 +85,12 @@ func TestLinesCollect(t *testing.T) {
 	assert.SliceEqual(t, items[1].Unwrap(), []byte("there"))
 }
 
+func TestLinesDrop(t *testing.T) {
+	items := iter.Lines(bytes.NewBufferString("hello\nthere")).Drop(1).Collect()
+	assert.Equal(t, 1, len(items))
+	assert.SliceEqual(t, items[0].Unwrap(), []byte("there"))
+}
+
 func TestLinesString(t *testing.T) {
 	file, err := os.Open("fixtures/lines.txt")
 	assert.Nil(t, err)
@@ -138,4 +144,9 @@ func TestLinesStringFailureLater(t *testing.T) {
 func TestLinesStringCollect(t *testing.T) {
 	items := iter.LinesString(bytes.NewBufferString("hello\nthere")).Collect()
 	assert.SliceEqual(t, items, []result.Result[string]{result.Ok("hello"), result.Ok("there")})
+}
+
+func TestLinesStringDrop(t *testing.T) {
+	items := iter.LinesString(bytes.NewBufferString("hello\nthere")).Drop(1).Collect()
+	assert.SliceEqual(t, items, []result.Result[string]{result.Ok("there")})
 }

--- a/iter/map.go
+++ b/iter/map.go
@@ -36,3 +36,8 @@ var _ Iterator[struct{}] = new(MapIter[struct{}, struct{}])
 func (iter *MapIter[T, U]) Collect() []U {
 	return Collect[U](iter)
 }
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *MapIter[T, U]) Drop(n uint) *DropIter[U] {
+	return Drop[U](iter, n)
+}

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -47,3 +47,9 @@ func TestMapCollect(t *testing.T) {
 	items := iter.Map[int, int](iter.Lift([]int{0, 1, 2, 3}), double).Collect()
 	assert.SliceEqual(t, items, []int{0, 2, 4, 6})
 }
+
+func TestMapDrop(t *testing.T) {
+	double := func(a int) int { return a * 2 }
+	items := iter.Map[int, int](iter.Lift([]int{0, 1, 2, 3}), double).Drop(2).Collect()
+	assert.SliceEqual(t, items, []int{4, 6})
+}

--- a/iter/repeat.go
+++ b/iter/repeat.go
@@ -20,3 +20,8 @@ func (iter *RepeatIter[T]) Next() option.Option[T] {
 }
 
 var _ Iterator[struct{}] = new(RepeatIter[struct{}])
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *RepeatIter[T]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}

--- a/iter/repeat_test.go
+++ b/iter/repeat_test.go
@@ -17,9 +17,14 @@ func ExampleRepeat() {
 	// Some(42)
 }
 
-func TestRepeatIter(t *testing.T) {
+func TestRepeat(t *testing.T) {
 	numbers := iter.Repeat[int](42)
 	assert.Equal(t, numbers.Next().Unwrap(), 42)
 	assert.Equal(t, numbers.Next().Unwrap(), 42)
+	assert.Equal(t, numbers.Next().Unwrap(), 42)
+}
+
+func TestRepeatDrop(t *testing.T) {
+	numbers := iter.Repeat[int](42).Drop(1)
 	assert.Equal(t, numbers.Next().Unwrap(), 42)
 }

--- a/iter/take.go
+++ b/iter/take.go
@@ -36,3 +36,8 @@ var _ Iterator[struct{}] = new(TakeIter[struct{}])
 func (iter *TakeIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *TakeIter[T]) Drop(n uint) *DropIter[T] {
+	return Drop[T](iter, n)
+}

--- a/iter/take_test.go
+++ b/iter/take_test.go
@@ -45,3 +45,8 @@ func TestTakeCollect(t *testing.T) {
 	items := iter.Take[int](iter.Count(), 3).Collect()
 	assert.SliceEqual(t, items, []int{0, 1, 2})
 }
+
+func TestTakeDrop(t *testing.T) {
+	items := iter.Take[int](iter.Count(), 3).Drop(1).Collect()
+	assert.SliceEqual(t, items, []int{1, 2})
+}

--- a/iter/zip.go
+++ b/iter/zip.go
@@ -44,3 +44,8 @@ var _ Iterator[Tuple[struct{}, struct{}]] = new(ZipIter[struct{}, struct{}])
 func (iter *ZipIter[T, U]) Collect() []Tuple[T, U] {
 	return Collect[Tuple[T, U]](iter)
 }
+
+// Drop is an alternative way of invoking Drop(iter)
+func (iter *ZipIter[T, U]) Drop(n uint) *DropIter[Tuple[T, U]] {
+	return Drop[Tuple[T, U]](iter, n)
+}

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -75,3 +75,12 @@ func TestZipCollect(t *testing.T) {
 	items := iter.Zip[int, int](evens, odds).Collect()
 	assert.SliceEqual(t, items, []iter.Tuple[int, int]{{0, 1}, {2, 3}})
 }
+
+func TestZipDrop(t *testing.T) {
+	isEven := func(a int) bool { return a%2 == 0 }
+	evens := iter.Filter[int](iter.Count(), isEven)
+	odds := iter.Take[int](iter.Exclude[int](iter.Count(), isEven), 2)
+
+	items := iter.Zip[int, int](evens, odds).Drop(1).Collect()
+	assert.SliceEqual(t, items, []iter.Tuple[int, int]{{2, 3}})
+}


### PR DESCRIPTION
**Please provide a brief description of the change.**

Support chaining the Drop iterator on other iterators.

**Which issue does this change relate to?**

https://github.com/BooleanCat/go-functional/issues/55

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
