### PR TITLE
Experiment: Add parser for generator directives

### DIFF
--- a/internal/gen/directive/directive.go
+++ b/internal/gen/directive/directive.go
@@ -1,0 +1,34 @@
+package directive
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/BooleanCat/go-functional/result"
+)
+
+var pattern = regexp.MustCompile(`^\/\/gofunctional:generate (?P<Type>\*[A-Z][A-Za-z]*(\[[A-Za-z]+\])?) (?P<YieldedType>[A-Za-z]+)(?P<Methods>( [A-Z][A-Za-z]*)+)$`)
+
+type Directive struct {
+	Type        string
+	YieldedType string
+	Methods     []string
+}
+
+func FromString(line string) result.Result[Directive] {
+	if !pattern.MatchString(line) {
+		return result.Err[Directive](fmt.Errorf("invalid directive: %s", line))
+	}
+
+	matches := pattern.FindStringSubmatch(line)
+	typeIndex := pattern.SubexpIndex("Type")
+	methodsIndex := pattern.SubexpIndex("Methods")
+	yieldedTypeIndex := pattern.SubexpIndex("YieldedType")
+
+	return result.Ok(Directive{
+		Type:        matches[typeIndex],
+		Methods:     strings.Split(strings.TrimSpace(matches[methodsIndex]), " "),
+		YieldedType: matches[yieldedTypeIndex],
+	})
+}

--- a/internal/gen/directive/directive_test.go
+++ b/internal/gen/directive/directive_test.go
@@ -1,0 +1,30 @@
+package directive_test
+
+import (
+	"testing"
+
+	"github.com/BooleanCat/go-functional/internal/assert"
+	"github.com/BooleanCat/go-functional/internal/gen/directive"
+)
+
+func TestFromString(t *testing.T) {
+	line := "//gofunctional:generate *CounterIter int Drop Take Chain"
+	d := directive.FromString(line).Unwrap()
+	assert.Equal(t, d.Type, "*CounterIter")
+	assert.Equal(t, d.YieldedType, "int")
+	assert.SliceEqual(t, d.Methods, []string{"Drop", "Take", "Chain"})
+}
+
+func TestFromStringOneMethod(t *testing.T) {
+	line := "//gofunctional:generate *TakeIter[T] T Drop"
+	d := directive.FromString(line).Unwrap()
+	assert.Equal(t, d.Type, "*TakeIter[T]")
+	assert.Equal(t, d.YieldedType, "T")
+	assert.SliceEqual(t, d.Methods, []string{"Drop"})
+}
+
+func TestFromInvalid(t *testing.T) {
+	line := "//gofunctional:generate *TakeIter[T] T"
+	err := directive.FromString(line).UnwrapErr()
+	assert.Equal(t, err.Error(), `invalid directive: //gofunctional:generate *TakeIter[T] T`)
+}


### PR DESCRIPTION
**Please provide a brief description of the change.**

In order to generate chainable methods, we need a parser for generator directives. This is that.

**Which issue does this change relate to?**

None.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
