### PR TITLE
Experiment: Support more complicated types for directives

### DIFF
--- a/internal/gen/directive/directive.go
+++ b/internal/gen/directive/directive.go
@@ -8,7 +8,10 @@ import (
 	"github.com/BooleanCat/go-functional/result"
 )
 
-var pattern = regexp.MustCompile(`^\/\/gofunctional:generate (?P<Type>\*[A-Z][A-Za-z]*(\[[A-Za-z]+\])?) (?P<YieldedType>[A-Za-z]+)(?P<Methods>( [A-Z][A-Za-z]*)+)$`)
+var (
+	typePattern = `\*?[A-Za-z]+(\[[A-Za-z](, [A-Za-z])*\])?`
+	pattern     = regexp.MustCompile(fmt.Sprintf(`^\/\/gofunctional:generate (?P<Type>%s) (?P<YieldedType>%s)(?P<Methods>( [A-Z][A-Za-z]*)+)$`, typePattern, typePattern))
+)
 
 type Directive struct {
 	Type        string

--- a/internal/gen/directive/directive_test.go
+++ b/internal/gen/directive/directive_test.go
@@ -8,19 +8,29 @@ import (
 )
 
 func TestFromString(t *testing.T) {
-	line := "//gofunctional:generate *CounterIter int Drop Take Chain"
-	d := directive.FromString(line).Unwrap()
-	assert.Equal(t, d.Type, "*CounterIter")
-	assert.Equal(t, d.YieldedType, "int")
-	assert.SliceEqual(t, d.Methods, []string{"Drop", "Take", "Chain"})
-}
-
-func TestFromStringOneMethod(t *testing.T) {
-	line := "//gofunctional:generate *TakeIter[T] T Drop"
-	d := directive.FromString(line).Unwrap()
-	assert.Equal(t, d.Type, "*TakeIter[T]")
-	assert.Equal(t, d.YieldedType, "T")
-	assert.SliceEqual(t, d.Methods, []string{"Drop"})
+	testCases := []struct {
+		candidate string
+		directive directive.Directive
+	}{
+		{
+			candidate: "//gofunctional:generate *CounterIter int Drop Take Chain",
+			directive: directive.Directive{Type: "*CounterIter", YieldedType: "int", Methods: []string{"Drop", "Take", "Chain"}},
+		},
+		{
+			candidate: "//gofunctional:generate *TakeIter[T] T Drop",
+			directive: directive.Directive{Type: "*TakeIter[T]", YieldedType: "T", Methods: []string{"Drop"}},
+		},
+		{
+			candidate: "//gofunctional:generate *TakeIter[T, U, V] Tuple[U, V] Drop Collect",
+			directive: directive.Directive{Type: "*TakeIter[T, U, V]", YieldedType: "Tuple[U, V]", Methods: []string{"Drop", "Collect"}},
+		},
+	}
+	for _, tc := range testCases {
+		got := directive.FromString(tc.candidate).Unwrap()
+		assert.Equal(t, tc.directive.Type, got.Type)
+		assert.Equal(t, tc.directive.YieldedType, got.YieldedType)
+		assert.SliceEqual(t, tc.directive.Methods, got.Methods)
+	}
 }
 
 func TestFromInvalid(t *testing.T) {


### PR DESCRIPTION
**Please provide a brief description of the change.**

Support more complicated types for directives. While building the code generator for method chaining I noticed the existing directives didn't support types like `Tuple[T, U]`.

**Which issue does this change relate to?**

None.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
