### PR TITLE
Add .ForEach for iterator method chaining

### DIFF
--- a/iter/chain.go
+++ b/iter/chain.go
@@ -32,10 +32,16 @@ func (iter *ChainIter[T]) Next() option.Option[T] {
 
 var _ Iterator[struct{}] = new(ChainIter[struct{}])
 
-// Collect is a convenience method for [Collect], providing this iterator as
-// an argument.
+// Collect is a convenience method for [Collect], providing this iterator as an
+// argument.
 func (iter *ChainIter[T]) Collect() []T {
 	return Collect[T](iter)
+}
+
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *ChainIter[T]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
 }
 
 // Drop is a convenience method for [Drop], providing this iterator as an

--- a/iter/chain_test.go
+++ b/iter/chain_test.go
@@ -46,16 +46,26 @@ func TestChainExhausted(t *testing.T) {
 }
 
 func TestChainCollect(t *testing.T) {
-	items := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Collect()
-	assert.SliceEqual(t, items, []int{1, 2, 3, 4})
+	numbers := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Collect()
+	assert.SliceEqual(t, numbers, []int{1, 2, 3, 4})
+}
+
+func TestChainForEach(t *testing.T) {
+	total := 0
+
+	iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).ForEach(func(number int) {
+		total += number
+	})
+
+	assert.Equal(t, total, 10)
 }
 
 func TestChainDrop(t *testing.T) {
-	items := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Drop(1).Collect()
-	assert.SliceEqual(t, items, []int{2, 3, 4})
+	numbers := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Drop(1).Collect()
+	assert.SliceEqual(t, numbers, []int{2, 3, 4})
 }
 
 func TestChainTake(t *testing.T) {
-	items := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Take(3).Collect()
-	assert.SliceEqual(t, items, []int{1, 2, 3})
+	numbers := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Take(3).Collect()
+	assert.SliceEqual(t, numbers, []int{1, 2, 3})
 }

--- a/iter/channel.go
+++ b/iter/channel.go
@@ -26,10 +26,16 @@ func (iter *ChannelIter[T]) Next() option.Option[T] {
 
 var _ Iterator[struct{}] = new(ChannelIter[struct{}])
 
-// Collect is a convenience method for [Collect], providing this iterator as
-// an argument.
+// Collect is a convenience method for [Collect], providing this iterator as an
+// argument.
 func (iter *ChannelIter[T]) Collect() []T {
 	return Collect[T](iter)
+}
+
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *ChannelIter[T]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
 }
 
 // Drop is a convenience method for [Drop], providing this iterator as an

--- a/iter/channel_test.go
+++ b/iter/channel_test.go
@@ -58,6 +58,25 @@ func TestFromChannelCollect(t *testing.T) {
 	assert.SliceEqual(t, numbers, []int{1, 2})
 }
 
+func TestFromChannelForEach(t *testing.T) {
+	ch := make(chan int)
+
+	go func() {
+		defer close(ch)
+		ch <- 1
+		ch <- 2
+		ch <- 3
+	}()
+
+	total := 0
+
+	iter.FromChannel(ch).ForEach(func(number int) {
+		total += number
+	})
+
+	assert.Equal(t, total, 6)
+}
+
 func TestFromChannelDrop(t *testing.T) {
 	ch := make(chan int)
 
@@ -86,5 +105,4 @@ func TestFromChannelTake(t *testing.T) {
 	numbers := iter.Take(2).Collect()
 	assert.SliceEqual(t, numbers, []int{1, 2})
 	iter.Collect() // To close the channel
-
 }

--- a/iter/counter.go
+++ b/iter/counter.go
@@ -22,6 +22,12 @@ func (c *CountIter) Next() option.Option[int] {
 
 var _ Iterator[int] = new(CountIter)
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *CountIter) ForEach(callback func(int)) {
+	ForEach[int](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (c *CountIter) Drop(n uint) *DropIter[int] {

--- a/iter/counter_test.go
+++ b/iter/counter_test.go
@@ -27,6 +27,18 @@ func TestCount(t *testing.T) {
 	assert.Equal(t, counter.Next().Unwrap(), 2)
 }
 
+func TestCountForEach(t *testing.T) {
+	defer func() {
+		assert.Equal(t, recover(), "oops")
+	}()
+
+	iter.Count().ForEach(func(_ int) {
+		panic("oops")
+	})
+
+	t.Error("did not panic")
+}
+
 func TestCountDrop(t *testing.T) {
 	counter := iter.Count().Drop(5)
 	assert.Equal(t, counter.Next().Unwrap(), 5)

--- a/iter/cycle.go
+++ b/iter/cycle.go
@@ -49,6 +49,12 @@ func (iter *CycleIter[T]) Next() option.Option[T] {
 
 var _ Iterator[struct{}] = new(CycleIter[struct{}])
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *CycleIter[T]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *CycleIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/cycle_test.go
+++ b/iter/cycle_test.go
@@ -39,6 +39,18 @@ func TestCycleExhausted(t *testing.T) {
 	assert.Equal(t, delegate.NextCallCount(), 1)
 }
 
+func TestCycleForEach(t *testing.T) {
+	defer func() {
+		assert.Equal(t, recover(), "oops")
+	}()
+
+	iter.Cycle[int](iter.Lift([]int{1, 2})).ForEach(func(_ int) {
+		panic("oops")
+	})
+
+	t.Error("did not panic")
+}
+
 func TestCycleDrop(t *testing.T) {
 	items := iter.Cycle[int](iter.Lift([]int{1, 2})).Drop(1).Take(5).Collect()
 	assert.SliceEqual(t, items, []int{2, 1, 2, 1, 2})

--- a/iter/drop.go
+++ b/iter/drop.go
@@ -52,6 +52,12 @@ func (iter *DropIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *DropIter[T]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *DropIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/drop_test.go
+++ b/iter/drop_test.go
@@ -55,6 +55,16 @@ func TestDropCollect(t *testing.T) {
 	assert.SliceEqual(t, numbers, []int{3})
 }
 
+func TestDropForEach(t *testing.T) {
+	total := 0
+
+	iter.Lift([]int{1, 2, 3, 4}).Drop(1).ForEach(func(number int) {
+		total += number
+	})
+
+	assert.Equal(t, total, 9)
+}
+
 func TestDropDrop(t *testing.T) {
 	counter := iter.Count().Drop(2).Drop(3)
 	assert.Equal(t, counter.Next().Unwrap(), 5)

--- a/iter/exhausted.go
+++ b/iter/exhausted.go
@@ -24,6 +24,12 @@ func (iter *ExhaustedIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *ExhaustedIter[T]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *ExhaustedIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/exhausted_test.go
+++ b/iter/exhausted_test.go
@@ -21,6 +21,16 @@ func TestExhaustedCollect(t *testing.T) {
 	assert.Empty[int](t, iter.Exhausted[int]().Collect())
 }
 
+func TestExhaustedForEach(t *testing.T) {
+	total := 0
+
+	iter.Exhausted[int]().ForEach(func(number int) {
+		total += number
+	})
+
+	assert.Equal(t, total, 0)
+}
+
 func TestExhaustedDrop(t *testing.T) {
 	assert.True(t, iter.Exhausted[int]().Drop(1).Next().IsNone())
 }

--- a/iter/filter.go
+++ b/iter/filter.go
@@ -42,6 +42,12 @@ func (iter *FilterIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *FilterIter[T]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *FilterIter[T]) Drop(n uint) *DropIter[T] {
@@ -101,6 +107,12 @@ func FilterMap[T any, U any](itr Iterator[T], fun func(T) option.Option[U]) *Fil
 // an argument.
 func (iter *FilterMapIter[T, U]) Collect() []U {
 	return Collect[U](iter)
+}
+
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *FilterMapIter[T, U]) ForEach(callback func(U)) {
+	ForEach[U](iter, callback)
 }
 
 // Drop is a convenience method for [Drop], providing this iterator as an

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -80,6 +80,18 @@ func TestFilterCollect(t *testing.T) {
 	assert.SliceEqual(t, evens, []int{0, 2})
 }
 
+func TestFilterForEach(t *testing.T) {
+	total := 0
+
+	isEven := func(number int) bool { return number%2 == 0 }
+
+	iter.Filter[int](iter.Lift([]int{1, 2, 3, 4}), isEven).ForEach(func(number int) {
+		total += number
+	})
+
+	assert.Equal(t, total, 6)
+}
+
 func TestFilterDrop(t *testing.T) {
 	zeros := iter.Filter[int](iter.Lift([]int{0, 1, 0, 0}), filters.IsZero[int]).Take(2).Collect()
 	assert.SliceEqual(t, zeros, []int{0, 0})
@@ -111,6 +123,18 @@ func TestExcludeCollect(t *testing.T) {
 	isEven := func(a int) bool { return a%2 == 0 }
 	odds := iter.Exclude[int](iter.Lift([]int{0, 1, 2, 3}), isEven).Collect()
 	assert.SliceEqual(t, odds, []int{1, 3})
+}
+
+func TestExcludeForEach(t *testing.T) {
+	total := 0
+
+	isEven := func(number int) bool { return number%2 == 0 }
+
+	iter.Exclude[int](iter.Lift([]int{1, 2, 3, 4}), isEven).ForEach(func(number int) {
+		total += number
+	})
+
+	assert.Equal(t, total, 4)
 }
 
 func TestExcludeDrop(t *testing.T) {
@@ -153,6 +177,16 @@ func TestFilterMapCollect(t *testing.T) {
 	).Collect()
 
 	assert.SliceEqual(t, doubles, []int{4, 8, 12})
+}
+
+func TestFilterMapForEach(t *testing.T) {
+	total := 0
+
+	iter.FilterMap[int](iter.Lift([]int{1, 2, 3, 4}), selectEvenAndDouble).ForEach(func(number int) {
+		total += number
+	})
+
+	assert.Equal(t, total, 12)
 }
 
 func TestFilterMapDrop(t *testing.T) {

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -21,6 +21,28 @@ func ExampleCollect_method() {
 	// Output: [0 1 2]
 }
 
+func ExampleForEach() {
+	iter.ForEach[int](iter.Lift([]int{1, 2, 3}), func(number int) {
+		fmt.Println(number)
+	})
+
+	// Output:
+	// 1
+	// 2
+	// 3
+}
+
+func ExampleForEach_method() {
+	iter.Lift([]int{1, 2, 3}).ForEach(func(number int) {
+		fmt.Println(number)
+	})
+
+	// Output:
+	// 1
+	// 2
+	// 3
+}
+
 func ExampleFold() {
 	sum := iter.Fold[int](iter.Count().Take(4), 0, ops.Add[int])
 

--- a/iter/lift.go
+++ b/iter/lift.go
@@ -38,6 +38,12 @@ func (iter *LiftIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *LiftIter[T]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *LiftIter[T]) Drop(n uint) *DropIter[T] {
@@ -129,6 +135,12 @@ func (iter *LiftHashMapIter[T, U]) Collect() []Tuple[T, U] {
 	return Collect[Tuple[T, U]](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *LiftHashMapIter[T, U]) ForEach(callback func(Tuple[T, U])) {
+	ForEach[Tuple[T, U]](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *LiftHashMapIter[T, U]) Drop(n uint) *DropIter[Tuple[T, U]] {
@@ -192,6 +204,12 @@ func (iter *LiftHashMapKeysIter[T, U]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *LiftHashMapKeysIter[T, U]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *LiftHashMapKeysIter[T, U]) Drop(n uint) *DropIter[T] {
@@ -253,6 +271,12 @@ var (
 // an argument.
 func (iter *LiftHashMapValuesIter[T, U]) Collect() []U {
 	return Collect[U](iter)
+}
+
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *LiftHashMapValuesIter[T, U]) ForEach(callback func(U)) {
+	ForEach[U](iter, callback)
 }
 
 // Drop is a convenience method for [Drop], providing this iterator as an

--- a/iter/lift_test.go
+++ b/iter/lift_test.go
@@ -32,6 +32,16 @@ func TestLiftCollect(t *testing.T) {
 	assert.SliceEqual(t, items, []int{1, 2})
 }
 
+func TestLiftForEach(t *testing.T) {
+	total := 0
+
+	iter.Lift([]int{1, 2, 3}).ForEach(func(number int) {
+		total += number
+	})
+
+	assert.Equal(t, total, 6)
+}
+
 func TestLiftDrop(t *testing.T) {
 	items := iter.Lift([]int{1, 2, 3}).Drop(1).Collect()
 	assert.SliceEqual(t, items, []int{2, 3})
@@ -97,6 +107,19 @@ func TestLiftHashMapCollect(t *testing.T) {
 	})
 
 	assert.SliceEqual(t, items, []iter.Tuple[string, string]{{"name", "pikachu"}, {"type", "electric"}})
+}
+
+func TestLiftHashMapForEach(t *testing.T) {
+	count := 0
+
+	iter.LiftHashMap(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	}).ForEach(func(keyValue iter.Tuple[string, string]) {
+		count++
+	})
+
+	assert.Equal(t, count, 2)
 }
 
 func TestLiftHashMapDrop(t *testing.T) {
@@ -179,6 +202,19 @@ func TestLiftHashMapKeysCollect(t *testing.T) {
 	assert.SliceEqual(t, keys, []string{"name", "type"})
 }
 
+func TestLiftHashMapKeysForEach(t *testing.T) {
+	count := 0
+
+	iter.LiftHashMapKeys(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	}).ForEach(func(keyValue string) {
+		count++
+	})
+
+	assert.Equal(t, count, 2)
+}
+
 func TestLiftHashMapKeysDrop(t *testing.T) {
 	keys := iter.LiftHashMapKeys(map[string]string{
 		"name": "pikachu",
@@ -255,6 +291,19 @@ func TestLiftHashMapValuesCollect(t *testing.T) {
 	sort.Strings(values)
 
 	assert.SliceEqual(t, values, []string{"electric", "pikachu"})
+}
+
+func TestLiftHashMapValuesForEach(t *testing.T) {
+	count := 0
+
+	iter.LiftHashMapValues(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	}).ForEach(func(keyValue string) {
+		count++
+	})
+
+	assert.Equal(t, count, 2)
 }
 
 func TestLiftHashMapValuesDrop(t *testing.T) {

--- a/iter/lines.go
+++ b/iter/lines.go
@@ -69,6 +69,12 @@ func (iter *LinesIter) Collect() []result.Result[[]byte] {
 	return Collect[result.Result[[]byte]](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *LinesIter) ForEach(callback func(result.Result[[]byte])) {
+	ForEach[result.Result[[]byte]](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *LinesIter) Drop(n uint) *DropIter[result.Result[[]byte]] {

--- a/iter/lines_test.go
+++ b/iter/lines_test.go
@@ -85,6 +85,16 @@ func TestLinesCollect(t *testing.T) {
 	assert.SliceEqual(t, items[1].Unwrap(), []byte("there"))
 }
 
+func TestLinesForEach(t *testing.T) {
+	count := 0
+
+	iter.Lines(bytes.NewBufferString("hello\nthere")).ForEach(func(_ result.Result[[]byte]) {
+		count++
+	})
+
+	assert.Equal(t, count, 2)
+}
+
 func TestLinesDrop(t *testing.T) {
 	items := iter.Lines(bytes.NewBufferString("hello\nthere")).Drop(1).Collect()
 	assert.Equal(t, 1, len(items))
@@ -150,6 +160,16 @@ func TestLinesStringFailureLater(t *testing.T) {
 func TestLinesStringCollect(t *testing.T) {
 	items := iter.LinesString(bytes.NewBufferString("hello\nthere")).Collect()
 	assert.SliceEqual(t, items, []result.Result[string]{result.Ok("hello"), result.Ok("there")})
+}
+
+func TestLinesStringForEach(t *testing.T) {
+	count := 0
+
+	iter.LinesString(bytes.NewBufferString("hello\nthere")).ForEach(func(_ result.Result[string]) {
+		count++
+	})
+
+	assert.Equal(t, count, 2)
 }
 
 func TestLinesStringDrop(t *testing.T) {

--- a/iter/map.go
+++ b/iter/map.go
@@ -38,6 +38,12 @@ func (iter *MapIter[T, U]) Collect() []U {
 	return Collect[U](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *MapIter[T, U]) ForEach(callback func(U)) {
+	ForEach[U](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *MapIter[T, U]) Drop(n uint) *DropIter[U] {

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -45,6 +45,18 @@ func TestMapCollect(t *testing.T) {
 	assert.SliceEqual(t, items, []int{0, 2, 4, 6})
 }
 
+func TestMapForEach(t *testing.T) {
+	total := 0
+
+	double := func(a int) int { return a * 2 }
+
+	iter.Map[int, int](iter.Lift([]int{0, 1, 2, 3}), double).ForEach(func(number int) {
+		total += number
+	})
+
+	assert.Equal(t, total, 12)
+}
+
 func TestMapDrop(t *testing.T) {
 	double := func(a int) int { return a * 2 }
 	items := iter.Map[int, int](iter.Lift([]int{0, 1, 2, 3}), double).Drop(2).Collect()

--- a/iter/repeat.go
+++ b/iter/repeat.go
@@ -21,6 +21,12 @@ func (iter *RepeatIter[T]) Next() option.Option[T] {
 
 var _ Iterator[struct{}] = new(RepeatIter[struct{}])
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *RepeatIter[T]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *RepeatIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/repeat_test.go
+++ b/iter/repeat_test.go
@@ -24,6 +24,18 @@ func TestRepeat(t *testing.T) {
 	assert.Equal(t, numbers.Next().Unwrap(), 42)
 }
 
+func TestRepeatForEach(t *testing.T) {
+	defer func() {
+		assert.Equal(t, recover(), "oops")
+	}()
+
+	iter.Repeat(42).ForEach(func(_ int) {
+		panic("oops")
+	})
+
+	t.Error("did not panic")
+}
+
 func TestRepeatDrop(t *testing.T) {
 	numbers := iter.Repeat[int](42).Drop(1)
 	assert.Equal(t, numbers.Next().Unwrap(), 42)

--- a/iter/take.go
+++ b/iter/take.go
@@ -38,6 +38,12 @@ func (iter *TakeIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *TakeIter[T]) ForEach(callback func(T)) {
+	ForEach[T](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *TakeIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/take_test.go
+++ b/iter/take_test.go
@@ -57,6 +57,16 @@ func TestTakeCollect(t *testing.T) {
 	assert.SliceEqual(t, items, []int{0, 1, 2})
 }
 
+func TestTakeForEach(t *testing.T) {
+	count := 0
+
+	iter.Take[int](iter.Count(), 2).ForEach(func(number int) {
+		count++
+	})
+
+	assert.Equal(t, count, 2)
+}
+
 func TestTakeDrop(t *testing.T) {
 	items := iter.Take[int](iter.Count(), 3).Drop(1).Collect()
 	assert.SliceEqual(t, items, []int{1, 2})

--- a/iter/zip.go
+++ b/iter/zip.go
@@ -47,6 +47,12 @@ func (iter *ZipIter[T, U]) Collect() []Tuple[T, U] {
 	return Collect[Tuple[T, U]](iter)
 }
 
+// ForEach is a convenience method for [ForEach], providing this iterator as an
+// argument.
+func (iter *ZipIter[T, U]) ForEach(callback func(Tuple[T, U])) {
+	ForEach[Tuple[T, U]](iter, callback)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *ZipIter[T, U]) Drop(n uint) *DropIter[Tuple[T, U]] {

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -76,6 +76,20 @@ func TestZipCollect(t *testing.T) {
 	assert.SliceEqual(t, items, []iter.Tuple[int, int]{{0, 1}, {2, 3}})
 }
 
+func TestZipForEach(t *testing.T) {
+	isEven := func(a int) bool { return a%2 == 0 }
+	evens := iter.Filter[int](iter.Count(), isEven)
+	odds := iter.Exclude[int](iter.Count(), isEven).Take(2)
+
+	totalOdd := 0
+
+	iter.Zip[int, int](evens, odds).ForEach(func(pairs iter.Tuple[int, int]) {
+		totalOdd += pairs.Two
+	})
+
+	assert.Equal(t, totalOdd, 4)
+}
+
 func TestZipDrop(t *testing.T) {
 	isEven := func(a int) bool { return a%2 == 0 }
 	evens := iter.Filter[int](iter.Count(), isEven)


### PR DESCRIPTION
**Please provide a brief description of the change.**

Add .ForEach for iterator method chaining

**Which issue does this change relate to?**

https://github.com/BooleanCat/go-functional/issues/55

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
