### PR TITLE
Add .ForEach for iterator method chaining

### DIFF
--- a/iter/chain.go
+++ b/iter/chain.go
@@ -44,6 +44,12 @@ func (iter *ChainIter[T]) ForEach(callback func(T)) {
 	ForEach[T](iter, callback)
 }
 
+// ForEach is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *ChainIter[T]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *ChainIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/chain_test.go
+++ b/iter/chain_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/BooleanCat/go-functional/internal/assert"
 	"github.com/BooleanCat/go-functional/internal/fakes"
 	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/option"
 )
 
 func ExampleChain() {
@@ -58,6 +59,14 @@ func TestChainForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, total, 10)
+}
+
+func TestChainFind(t *testing.T) {
+	number := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4})).Find(func(number int) bool {
+		return number == 3
+	})
+
+	assert.Equal(t, number, option.Some(3))
 }
 
 func TestChainDrop(t *testing.T) {

--- a/iter/channel.go
+++ b/iter/channel.go
@@ -38,6 +38,12 @@ func (iter *ChannelIter[T]) ForEach(callback func(T)) {
 	ForEach[T](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *ChannelIter[T]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *ChannelIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/channel_test.go
+++ b/iter/channel_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BooleanCat/go-functional/internal/assert"
 	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/option"
 )
 
 func ExampleFromChannel() {
@@ -75,6 +76,26 @@ func TestFromChannelForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, total, 6)
+}
+
+func TestFromChannelFind(t *testing.T) {
+	ch := make(chan int)
+
+	go func() {
+		defer close(ch)
+		ch <- 1
+		ch <- 2
+		ch <- 3
+	}()
+
+	numbers := iter.FromChannel(ch)
+	defer numbers.Collect()
+
+	number := numbers.Find(func(number int) bool {
+		return number == 2
+	})
+
+	assert.Equal(t, number, option.Some(2))
 }
 
 func TestFromChannelDrop(t *testing.T) {

--- a/iter/counter.go
+++ b/iter/counter.go
@@ -28,6 +28,12 @@ func (iter *CountIter) ForEach(callback func(int)) {
 	ForEach[int](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *CountIter) Find(predicate func(int) bool) option.Option[int] {
+	return Find[int](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (c *CountIter) Drop(n uint) *DropIter[int] {

--- a/iter/counter_test.go
+++ b/iter/counter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BooleanCat/go-functional/internal/assert"
 	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/option"
 )
 
 func ExampleCount() {
@@ -37,6 +38,12 @@ func TestCountForEach(t *testing.T) {
 	})
 
 	t.Error("did not panic")
+}
+
+func TestCountFind(t *testing.T) {
+	assert.Equal(t, iter.Count().Find(func(number int) bool {
+		return number == 5
+	}), option.Some(5))
 }
 
 func TestCountDrop(t *testing.T) {

--- a/iter/cycle.go
+++ b/iter/cycle.go
@@ -55,6 +55,12 @@ func (iter *CycleIter[T]) ForEach(callback func(T)) {
 	ForEach[T](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *CycleIter[T]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *CycleIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/cycle_test.go
+++ b/iter/cycle_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/BooleanCat/go-functional/internal/assert"
 	"github.com/BooleanCat/go-functional/internal/fakes"
 	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/option"
 )
 
 func ExampleCycle() {
@@ -49,6 +50,12 @@ func TestCycleForEach(t *testing.T) {
 	})
 
 	t.Error("did not panic")
+}
+
+func TestCycleFind(t *testing.T) {
+	assert.Equal(t, iter.Cycle[int](iter.Lift([]int{1, 2})).Find(func(number int) bool {
+		return number == 2
+	}), option.Some(2))
 }
 
 func TestCycleDrop(t *testing.T) {

--- a/iter/drop.go
+++ b/iter/drop.go
@@ -58,6 +58,12 @@ func (iter *DropIter[T]) ForEach(callback func(T)) {
 	ForEach[T](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *DropIter[T]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *DropIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/drop_test.go
+++ b/iter/drop_test.go
@@ -65,6 +65,12 @@ func TestDropForEach(t *testing.T) {
 	assert.Equal(t, total, 9)
 }
 
+func TestDropFind(t *testing.T) {
+	assert.Equal(t, iter.Drop[int](iter.Count(), 5).Find(func(number int) bool {
+		return number%4 == 0
+	}), option.Some(8))
+}
+
 func TestDropDrop(t *testing.T) {
 	counter := iter.Count().Drop(2).Drop(3)
 	assert.Equal(t, counter.Next().Unwrap(), 5)

--- a/iter/exhausted.go
+++ b/iter/exhausted.go
@@ -24,6 +24,12 @@ func (iter *ExhaustedIter[T]) Collect() []T {
 	return Collect[T](iter)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *ExhaustedIter[T]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // ForEach is a convenience method for [ForEach], providing this iterator as an
 // argument.
 func (iter *ExhaustedIter[T]) ForEach(callback func(T)) {

--- a/iter/exhausted_test.go
+++ b/iter/exhausted_test.go
@@ -31,6 +31,12 @@ func TestExhaustedForEach(t *testing.T) {
 	assert.Equal(t, total, 0)
 }
 
+func TestExhaustedFind(t *testing.T) {
+	assert.True(t, iter.Exhausted[int]().Find(func(number int) bool {
+		return number == 0
+	}).IsNone())
+}
+
 func TestExhaustedDrop(t *testing.T) {
 	assert.True(t, iter.Exhausted[int]().Drop(1).Next().IsNone())
 }

--- a/iter/filter.go
+++ b/iter/filter.go
@@ -48,6 +48,12 @@ func (iter *FilterIter[T]) ForEach(callback func(T)) {
 	ForEach[T](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *FilterIter[T]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *FilterIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -87,6 +87,12 @@ func TestFilterForEach(t *testing.T) {
 	assert.Equal(t, total, 6)
 }
 
+func TestFilterFind(t *testing.T) {
+	assert.Equal(t, iter.Filter[int](iter.Count(), filters.IsEven[int]).Find(func(number int) bool {
+		return number == 2
+	}), option.Some(2))
+}
+
 func TestFilterDrop(t *testing.T) {
 	zeros := iter.Filter[int](iter.Lift([]int{0, 1, 0, 0}), filters.IsZero[int]).Take(2).Collect()
 	assert.SliceEqual(t, zeros, []int{0, 0})
@@ -125,6 +131,12 @@ func TestExcludeForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, total, 4)
+}
+
+func TestExcludeFind(t *testing.T) {
+	assert.Equal(t, iter.Exclude[int](iter.Count(), filters.IsEven[int]).Find(func(number int) bool {
+		return number == 3
+	}), option.Some(3))
 }
 
 func TestExcludeDrop(t *testing.T) {

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -69,6 +69,15 @@ func ExampleFind() {
 	// Output: Some(bar)
 }
 
+func ExampleFind_method() {
+	bar := iter.Lift([]string{"foo", "bar", "baz"}).Find(func(v string) bool {
+		return v == "bar"
+	})
+
+	fmt.Println(bar)
+	// Output: Some(bar)
+}
+
 func TestCollect(t *testing.T) {
 	items := iter.Collect[int](iter.Count().Take(5))
 	assert.SliceEqual(t, items, []int{0, 1, 2, 3, 4})

--- a/iter/lift.go
+++ b/iter/lift.go
@@ -44,6 +44,12 @@ func (iter *LiftIter[T]) ForEach(callback func(T)) {
 	ForEach[T](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *LiftIter[T]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *LiftIter[T]) Drop(n uint) *DropIter[T] {
@@ -141,6 +147,12 @@ func (iter *LiftHashMapIter[T, U]) ForEach(callback func(Tuple[T, U])) {
 	ForEach[Tuple[T, U]](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *LiftHashMapIter[T, U]) Find(predicate func(Tuple[T, U]) bool) option.Option[Tuple[T, U]] {
+	return Find[Tuple[T, U]](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *LiftHashMapIter[T, U]) Drop(n uint) *DropIter[Tuple[T, U]] {
@@ -210,6 +222,12 @@ func (iter *LiftHashMapKeysIter[T, U]) ForEach(callback func(T)) {
 	ForEach[T](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *LiftHashMapKeysIter[T, U]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *LiftHashMapKeysIter[T, U]) Drop(n uint) *DropIter[T] {
@@ -277,6 +295,12 @@ func (iter *LiftHashMapValuesIter[T, U]) Collect() []U {
 // argument.
 func (iter *LiftHashMapValuesIter[T, U]) ForEach(callback func(U)) {
 	ForEach[U](iter, callback)
+}
+
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *LiftHashMapValuesIter[T, U]) Find(predicate func(U) bool) option.Option[U] {
+	return Find[U](iter, predicate)
 }
 
 // Drop is a convenience method for [Drop], providing this iterator as an

--- a/iter/lift.go
+++ b/iter/lift.go
@@ -80,7 +80,7 @@ type LiftHashMapIter[T comparable, U any] struct {
 // necessary to call Close if exhaustion is guaranteed, but may be wise to
 // redundantly call Close if you're unsure.
 func LiftHashMap[T comparable, U any](hashmap map[T]U) *LiftHashMapIter[T, U] {
-	iter := &LiftHashMapIter[T, U]{hashmap, make(chan Tuple[T, U]), sync.Once{}, make(chan struct{})}
+	iter := &LiftHashMapIter[T, U]{hashmap, make(chan Tuple[T, U]), sync.Once{}, make(chan struct{}, 1)}
 
 	go func() {
 		defer close(iter.items)

--- a/iter/lift_test.go
+++ b/iter/lift_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BooleanCat/go-functional/internal/assert"
 	"github.com/BooleanCat/go-functional/iter"
 	"github.com/BooleanCat/go-functional/iter/filters"
+	"github.com/BooleanCat/go-functional/option"
 )
 
 func ExampleLift() {
@@ -40,6 +41,12 @@ func TestLiftForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, total, 6)
+}
+
+func TestLiftFind(t *testing.T) {
+	assert.Equal(t, iter.Lift([]int{1, 2, 3}).Find(func(number int) bool {
+		return number == 2
+	}), option.Some(2))
 }
 
 func TestLiftDrop(t *testing.T) {
@@ -120,6 +127,18 @@ func TestLiftHashMapForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, count, 2)
+}
+
+func TestLiftHashMapFind(t *testing.T) {
+	pokemon := iter.LiftHashMap[string, string](map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	})
+	defer pokemon.Close()
+
+	assert.Equal(t, pokemon.Find(func(keyValue iter.Tuple[string, string]) bool {
+		return keyValue.One == "type"
+	}), option.Some(iter.Tuple[string, string]{"type", "electric"}))
 }
 
 func TestLiftHashMapDrop(t *testing.T) {
@@ -215,6 +234,18 @@ func TestLiftHashMapKeysForEach(t *testing.T) {
 	assert.Equal(t, count, 2)
 }
 
+func TestLiftHashMapKeysFind(t *testing.T) {
+	pokemon := iter.LiftHashMapKeys(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	})
+	defer pokemon.Close()
+
+	assert.Equal(t, pokemon.Find(func(key string) bool {
+		return key == "type"
+	}), option.Some("type"))
+}
+
 func TestLiftHashMapKeysDrop(t *testing.T) {
 	keys := iter.LiftHashMapKeys(map[string]string{
 		"name": "pikachu",
@@ -304,6 +335,18 @@ func TestLiftHashMapValuesForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, count, 2)
+}
+
+func TestLiftHashMapValuesFind(t *testing.T) {
+	pokemon := iter.LiftHashMapValues(map[string]string{
+		"name": "pikachu",
+		"type": "electric",
+	})
+	defer pokemon.Close()
+
+	assert.Equal(t, pokemon.Find(func(value string) bool {
+		return value == "electric"
+	}), option.Some("electric"))
 }
 
 func TestLiftHashMapValuesDrop(t *testing.T) {

--- a/iter/lines.go
+++ b/iter/lines.go
@@ -75,6 +75,12 @@ func (iter *LinesIter) ForEach(callback func(result.Result[[]byte])) {
 	ForEach[result.Result[[]byte]](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *LinesIter) Find(predicate func(result.Result[[]byte]) bool) option.Option[result.Result[[]byte]] {
+	return Find[result.Result[[]byte]](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *LinesIter) Drop(n uint) *DropIter[result.Result[[]byte]] {

--- a/iter/lines_test.go
+++ b/iter/lines_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/BooleanCat/go-functional/internal/fakes"
 	"github.com/BooleanCat/go-functional/iter"
 	"github.com/BooleanCat/go-functional/iter/ops"
+	"github.com/BooleanCat/go-functional/option"
 	"github.com/BooleanCat/go-functional/result"
 )
 
@@ -95,6 +96,14 @@ func TestLinesForEach(t *testing.T) {
 	assert.Equal(t, count, 2)
 }
 
+func TestLinesFind(t *testing.T) {
+	item := iter.Lines(bytes.NewBufferString("hello\nthere")).Find(func(item result.Result[[]byte]) bool {
+		return bytes.Equal(item.Unwrap(), []byte("there"))
+	})
+
+	assert.SliceEqual[byte](t, item.Unwrap().Unwrap(), []byte("there"))
+}
+
 func TestLinesDrop(t *testing.T) {
 	items := iter.Lines(bytes.NewBufferString("hello\nthere")).Drop(1).Collect()
 	assert.Equal(t, 1, len(items))
@@ -170,6 +179,14 @@ func TestLinesStringForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, count, 2)
+}
+
+func TestLinesStringFind(t *testing.T) {
+	item := iter.LinesString(bytes.NewBufferString("hello\nthere")).Find(func(item result.Result[string]) bool {
+		return item.Unwrap() == "there"
+	})
+
+	assert.Equal(t, item, option.Some(result.Ok("there")))
 }
 
 func TestLinesStringDrop(t *testing.T) {

--- a/iter/map.go
+++ b/iter/map.go
@@ -44,6 +44,12 @@ func (iter *MapIter[T, U]) ForEach(callback func(U)) {
 	ForEach[U](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *MapIter[T, U]) Find(predicate func(U) bool) option.Option[U] {
+	return Find[U](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *MapIter[T, U]) Drop(n uint) *DropIter[U] {

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BooleanCat/go-functional/internal/fakes"
 	"github.com/BooleanCat/go-functional/iter"
 	"github.com/BooleanCat/go-functional/iter/ops"
+	"github.com/BooleanCat/go-functional/option"
 )
 
 func ExampleMap() {
@@ -55,6 +56,13 @@ func TestMapForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, total, 12)
+}
+
+func TestMapFind(t *testing.T) {
+	double := func(a int) int { return a * 2 }
+	assert.Equal(t, iter.Map[int, int](iter.Lift([]int{0, 1, 2, 3}), double).Find(func(number int) bool {
+		return number == 4
+	}), option.Some(4))
 }
 
 func TestMapDrop(t *testing.T) {

--- a/iter/repeat.go
+++ b/iter/repeat.go
@@ -27,6 +27,12 @@ func (iter *RepeatIter[T]) ForEach(callback func(T)) {
 	ForEach[T](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *RepeatIter[T]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *RepeatIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/repeat_test.go
+++ b/iter/repeat_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BooleanCat/go-functional/internal/assert"
 	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/option"
 )
 
 func ExampleRepeat() {
@@ -34,6 +35,12 @@ func TestRepeatForEach(t *testing.T) {
 	})
 
 	t.Error("did not panic")
+}
+
+func TestRepeatFind(t *testing.T) {
+	assert.Equal(t, iter.Repeat[int](42).Find(func(number int) bool {
+		return number == 42
+	}), option.Some(42))
 }
 
 func TestRepeatDrop(t *testing.T) {

--- a/iter/take.go
+++ b/iter/take.go
@@ -44,6 +44,12 @@ func (iter *TakeIter[T]) ForEach(callback func(T)) {
 	ForEach[T](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *TakeIter[T]) Find(predicate func(T) bool) option.Option[T] {
+	return Find[T](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *TakeIter[T]) Drop(n uint) *DropIter[T] {

--- a/iter/take_test.go
+++ b/iter/take_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/BooleanCat/go-functional/internal/assert"
 	"github.com/BooleanCat/go-functional/internal/fakes"
 	"github.com/BooleanCat/go-functional/iter"
+	"github.com/BooleanCat/go-functional/option"
 )
 
 func ExampleTake() {
@@ -65,6 +66,12 @@ func TestTakeForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, count, 2)
+}
+
+func TestTakeFind(t *testing.T) {
+	assert.Equal(t, iter.Take[int](iter.Count(), 3).Find(func(number int) bool {
+		return number == 2
+	}), option.Some(2))
 }
 
 func TestTakeDrop(t *testing.T) {

--- a/iter/zip.go
+++ b/iter/zip.go
@@ -53,6 +53,12 @@ func (iter *ZipIter[T, U]) ForEach(callback func(Tuple[T, U])) {
 	ForEach[Tuple[T, U]](iter, callback)
 }
 
+// Find is a convenience method for [Find], providing this iterator as an
+// argument.
+func (iter *ZipIter[T, U]) Find(predicate func(Tuple[T, U]) bool) option.Option[Tuple[T, U]] {
+	return Find[Tuple[T, U]](iter, predicate)
+}
+
 // Drop is a convenience method for [Drop], providing this iterator as an
 // argument.
 func (iter *ZipIter[T, U]) Drop(n uint) *DropIter[Tuple[T, U]] {

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BooleanCat/go-functional/internal/fakes"
 	"github.com/BooleanCat/go-functional/iter"
 	"github.com/BooleanCat/go-functional/iter/filters"
+	"github.com/BooleanCat/go-functional/option"
 )
 
 func ExampleZip() {
@@ -81,6 +82,17 @@ func TestZipForEach(t *testing.T) {
 	})
 
 	assert.Equal(t, totalOdd, 4)
+}
+
+func TestZipFind(t *testing.T) {
+	evens := iter.Filter[int](iter.Count(), filters.IsEven[int])
+	odds := iter.Filter[int](iter.Count(), filters.IsOdd[int]).Take(2)
+
+	item := iter.Zip[int, int](evens, odds).Find(func(pairs iter.Tuple[int, int]) bool {
+		return pairs.One == 2
+	})
+
+	assert.Equal(t, item, option.Some(iter.Tuple[int, int]{2, 3}))
 }
 
 func TestZipDrop(t *testing.T) {


### PR DESCRIPTION
**Please provide a brief description of the change.**

Add .ForEach for iterator method chaining

Also fixes a deadlock in HashMap iterators

**Which issue does this change relate to?**

https://github.com/BooleanCat/go-functional/issues/55

**Contribution checklist.**

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] My code is formatted (`make check`)
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies