### PR TITLE
feat: added golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,49 @@
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 3m
+
+linters-settings:
+  cyclop:
+    # The maximal code complexity to report.
+    # Default: 10
+    max-complexity: 15
+    # The maximal average package complexity.
+    # If it's higher than 0.0 (float) the check is enabled
+    # Default: 0.0
+    package-average: 0.5
+    # Should ignore tests.
+    # Default: false
+    skip-tests: false
+
+  govet:
+    # Report about shadowed variables.
+    # Default: false
+    check-shadowing: true
+    # Enable all analyzers.
+    enable-all: true
+
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    # Default is to use a neutral variety of English.
+    locale: US
+
+linters:
+  # Disable all linters.
+  # Default: false
+  disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    # Default
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    # Other linters for report card
+    - gofmt
+    - gocyclo
+    - misspell


### PR DESCRIPTION
**Description of the change.**
Added configurations to setup `golangci-lint`.

following command will run all the linter
```
make lint
```

Example of lint error
```
iter/chain.go:13:43: `colour` is a misspelling of `color` (misspell)
// iterators to exhaustion first to last. colour
                                          ^
make: *** [lint] Error 1
```


**Which issue does this change relate to?**
Resolves : https://github.com/BooleanCat/go-functional/issues/77


**Contribution checklist.**
- [X] I have read and understood the CONTRIBUTING guidelines
- [X] My code is formatted (`make check`)
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [ ] I have added relevant tests
- [X] I have not added any dependencies
