### PR TITLE
Add Result.Unmarshal unmarshaling method

### DIFF
--- a/result/json.go
+++ b/result/json.go
@@ -14,3 +14,5 @@ func (r *Result[T]) UnmarshalJSON(data []byte) error {
 	*r = Ok(value)
 	return nil
 }
+
+var _ json.Unmarshaler = &Result[struct{}]{}

--- a/result/json.go
+++ b/result/json.go
@@ -1,0 +1,16 @@
+package result
+
+import "encoding/json"
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface.
+// Values will be unmarshaled as [Ok] variants.
+func (r *Result[T]) UnmarshalJSON(data []byte) error {
+	var value T
+
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	*r = Ok(value)
+	return nil
+}

--- a/result/json_test.go
+++ b/result/json_test.go
@@ -32,3 +32,11 @@ func TestUnmarshalJSON(t *testing.T) {
 
 	assert.SliceEqual(t, value, []string{"Foo", "Bar"})
 }
+
+func TestUnmarshalError(t *testing.T) {
+	var r result.Result[string]
+
+	err := json.Unmarshal([]byte("42"), &r)
+
+	assert.NotNil(t, err)
+}

--- a/result/json_test.go
+++ b/result/json_test.go
@@ -1,0 +1,34 @@
+package result_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/BooleanCat/go-functional/internal/assert"
+	"github.com/BooleanCat/go-functional/result"
+	"testing"
+)
+
+func ExampleResult_UnmarshalJSON() {
+	var r result.Result[[]string]
+
+	_ = json.Unmarshal([]byte(`["Foo", "Bar"]`), &r)
+
+	value, _ := r.Value()
+
+	fmt.Println(value)
+
+	// Output:
+	// [Foo Bar]
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	var r result.Result[[]string]
+
+	err := json.Unmarshal([]byte(`["Foo", "Bar"]`), &r)
+	assert.Nil(t, err)
+
+	value, err := r.Value()
+	assert.Nil(t, err)
+
+	assert.SliceEqual(t, value, []string{"Foo", "Bar"})
+}

--- a/result/result.go
+++ b/result/result.go
@@ -1,6 +1,9 @@
 package result
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Result represents failure or success. The [Ok] variant represents success
 // and contains a value. The [Err] variant represent a failure and contains an
@@ -96,4 +99,17 @@ func (r Result[T]) UnwrapErr() error {
 	}
 
 	return r.err
+}
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface.
+// Values will be unmarshaled as [Ok] variants.
+func (r *Result[T]) UnmarshalJSON(data []byte) error {
+	var value T
+
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	*r = Ok(value)
+	return nil
 }

--- a/result/result.go
+++ b/result/result.go
@@ -1,7 +1,6 @@
 package result
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -99,17 +98,4 @@ func (r Result[T]) UnwrapErr() error {
 	}
 
 	return r.err
-}
-
-// UnmarshalJSON implements the [json.Unmarshaler] interface.
-// Values will be unmarshaled as [Ok] variants.
-func (r *Result[T]) UnmarshalJSON(data []byte) error {
-	var value T
-
-	if err := json.Unmarshal(data, &value); err != nil {
-		return err
-	}
-
-	*r = Ok(value)
-	return nil
 }

--- a/result/result_test.go
+++ b/result/result_test.go
@@ -1,7 +1,6 @@
 package result_test
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -78,21 +77,6 @@ func ExampleResult_UnwrapErr() {
 	err := result.Err[int](errors.New("oops")).UnwrapErr()
 	fmt.Println(err)
 	// Output: oops
-}
-
-func ExampleResult_UnmarshalJSON() {
-	var r result.Result[[]string]
-
-	_ = json.Unmarshal([]byte(`["Ford", "BMW", "Fiat"]`), &r)
-
-	value, err := r.Value()
-
-	fmt.Println(value)
-	fmt.Println(err)
-
-	// Output:
-	// [Ford BMW Fiat]
-	// <nil>
 }
 
 func TestOkStringer(t *testing.T) {
@@ -175,16 +159,4 @@ func TestOkUnwrapErr(t *testing.T) {
 
 	_ = result.Ok(42).UnwrapErr()
 	t.Error("did not panic")
-}
-
-func TestUnmarshalJSON(t *testing.T) {
-	var r result.Result[[]string]
-
-	err := json.Unmarshal([]byte(`["Ford", "BMW", "Fiat"]`), &r)
-	assert.Nil(t, err)
-
-	value, err := r.Value()
-	assert.Nil(t, err)
-
-	assert.SliceEqual(t, value, []string{"Ford", "BMW", "Fiat"})
 }

--- a/result/result_test.go
+++ b/result/result_test.go
@@ -1,6 +1,7 @@
 package result_test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -77,6 +78,21 @@ func ExampleResult_UnwrapErr() {
 	err := result.Err[int](errors.New("oops")).UnwrapErr()
 	fmt.Println(err)
 	// Output: oops
+}
+
+func ExampleResult_UnmarshalJSON() {
+	var r result.Result[[]string]
+
+	_ = json.Unmarshal([]byte(`["Ford", "BMW", "Fiat"]`), &r)
+
+	value, err := r.Value()
+
+	fmt.Println(value)
+	fmt.Println(err)
+
+	// Output:
+	// [Ford BMW Fiat]
+	// <nil>
 }
 
 func TestOkStringer(t *testing.T) {
@@ -159,4 +175,16 @@ func TestOkUnwrapErr(t *testing.T) {
 
 	_ = result.Ok(42).UnwrapErr()
 	t.Error("did not panic")
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	var r result.Result[[]string]
+
+	err := json.Unmarshal([]byte(`["Ford", "BMW", "Fiat"]`), &r)
+	assert.Nil(t, err)
+
+	value, err := r.Value()
+	assert.Nil(t, err)
+
+	assert.SliceEqual(t, value, []string{"Ford", "BMW", "Fiat"})
 }


### PR DESCRIPTION
**Please provide a brief description of the change.**

Add the `Unmarshal` method to the **Result** struct.

**Which issue does this change relate to?**

https://github.com/BooleanCat/go-functional/issues/79

**Contribution checklist.**

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] My code is formatted (`make check`)
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies

**Additional context**

None
