### PR TITLE
feat: add stringer implementation for `iter.Pair[T, U]`

### DIFF
--- a/iter/enumerate_test.go
+++ b/iter/enumerate_test.go
@@ -17,8 +17,8 @@ func ExampleEnumerate() {
 	fmt.Println(iterator.Next())
 
 	// Output:
-	// Some({0 Hello})
-	// Some({1 Friend})
+	// Some((0, Hello))
+	// Some((1, Friend))
 	// None
 }
 
@@ -29,8 +29,8 @@ func ExampleEnumerate_method() {
 	fmt.Println(iterator.Next())
 
 	// Output:
-	// Some({0 Hello})
-	// Some({1 Friend})
+	// Some((0, Hello))
+	// Some((1, Friend))
 	// None
 }
 

--- a/iter/zip.go
+++ b/iter/zip.go
@@ -1,11 +1,30 @@
 package iter
 
-import "github.com/BooleanCat/go-functional/option"
+import (
+	"fmt"
+
+	"github.com/BooleanCat/go-functional/option"
+)
 
 // Pairs of values.
 type Pair[T, U any] struct {
 	One T
 	Two U
+}
+
+func (p Pair[T, U]) String() string {
+	one := fmt.Sprintf("%+v", p.One)
+	two := fmt.Sprintf("%+v", p.Two)
+
+	if val, ok := interface{}(p.One).(fmt.Stringer); ok {
+		one = val.String()
+	}
+
+	if val, ok := interface{}(p.Two).(fmt.Stringer); ok {
+		two = val.String()
+	}
+
+	return fmt.Sprintf("(%s,%s)", one, two)
 }
 
 // ZipIter iterator, see [Zip].

--- a/iter/zip.go
+++ b/iter/zip.go
@@ -24,7 +24,7 @@ func (p Pair[T, U]) String() string {
 		two = val.String()
 	}
 
-	return fmt.Sprintf("(%s,%s)", one, two)
+	return fmt.Sprintf("(%s, %s)", one, two)
 }
 
 // ZipIter iterator, see [Zip].

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -15,7 +15,7 @@ func ExampleZip() {
 	odds := iter.Filter[int](iter.Count(), filters.IsOdd[int])
 
 	fmt.Println(iter.Zip[int, int](evens, odds).Take(3).Collect())
-	// Output: [{0 1} {2 3} {4 5}]
+	// Output:[(0, 1) (2, 3) (4, 5)]
 }
 
 func TestPairStringer(t *testing.T) {
@@ -25,8 +25,8 @@ func TestPairStringer(t *testing.T) {
 	pair1 := iter.Pair[string, interface{}]{One: "1", Two: foo}
 	pair2 := iter.Pair[int, interface{}]{One: 2, Two: pair1}
 
-	assert.Equal(t, pair1.String(), "(1,map[text:Random Text])")
-	assert.Equal(t, pair2.String(), "(2,(1,map[text:Random Text]))")
+	assert.Equal(t, pair1.String(), "(1, map[text:Random Text])")
+	assert.Equal(t, pair2.String(), "(2, (1, map[text:Random Text]))")
 }
 
 func TestZip(t *testing.T) {

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -18,6 +18,17 @@ func ExampleZip() {
 	// Output: [{0 1} {2 3} {4 5}]
 }
 
+func TestPairStringer(t *testing.T) {
+	foo := map[string]interface{}{
+		"text": "Random Text",
+	}
+	pair1 := iter.Pair[string, interface{}]{One: "1", Two: foo}
+	pair2 := iter.Pair[int, interface{}]{One: 2, Two: pair1}
+
+	assert.Equal(t, pair1.String(), "(1,map[text:Random Text])")
+	assert.Equal(t, pair2.String(), "(2,(1,map[text:Random Text]))")
+}
+
 func TestZip(t *testing.T) {
 	evens := iter.Filter[int](iter.Count(), filters.IsEven[int])
 	odds := iter.Filter[int](iter.Count(), filters.IsOdd[int])

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -24,9 +24,11 @@ func TestPairStringer(t *testing.T) {
 	}
 	pair1 := iter.Pair[string, interface{}]{One: "1", Two: foo}
 	pair2 := iter.Pair[int, interface{}]{One: 2, Two: pair1}
+	pair3 := iter.Pair[interface{}, interface{}]{One: pair1, Two: pair2}
 
 	assert.Equal(t, pair1.String(), "(1, map[text:Random Text])")
 	assert.Equal(t, pair2.String(), "(2, (1, map[text:Random Text]))")
+	assert.Equal(t, pair3.String(), "((1, map[text:Random Text]), (2, (1, map[text:Random Text])))")
 }
 
 func TestZip(t *testing.T) {


### PR DESCRIPTION
**Please provide a brief description of the change.**

Added stringer implementation for `iter.Pair[T, U]`

Example
```golang
pair1 := iter.Pair[string, interface{}]{One: "1", Two:"2"}
fmt.Printf("%s\n", foo)
```
Output
```
(1,2)
```
**Which issue does this change relate to?**
https://github.com/BooleanCat/go-functional/issues/82

**Contribution checklist.**

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] My code is formatted (`make check`)
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies
