### PR TITLE
feat: Add Stringer interface impl for iter.CountIter

### DIFF
--- a/iter/counter.go
+++ b/iter/counter.go
@@ -28,7 +28,7 @@ func (c *CountIter) Next() option.Option[int] {
 }
 
 // String implements the [fmt.Stringer] interface
-func (c *CountIter) String() string {
+func (c CountIter) String() string {
 	return "Iterator<Count>"
 }
 

--- a/iter/counter.go
+++ b/iter/counter.go
@@ -1,6 +1,10 @@
 package iter
 
-import "github.com/BooleanCat/go-functional/option"
+import (
+	"fmt"
+
+	"github.com/BooleanCat/go-functional/option"
+)
 
 // CountIter iterator, see [Count].
 type CountIter struct {
@@ -23,4 +27,10 @@ func (c *CountIter) Next() option.Option[int] {
 	return option.Some(c.index - 1)
 }
 
+// String implements the [fmt.Stringer] interface
+func (c *CountIter) String() string {
+	return "Iterator<Count>"
+}
+
+var _ fmt.Stringer = new(CountIter)
 var _ Iterator[int] = new(CountIter)

--- a/iter/counter_test.go
+++ b/iter/counter_test.go
@@ -23,7 +23,7 @@ func ExampleCount() {
 func ExampleCountIter_String() {
 	counter := iter.Count()
 	fmt.Println(counter)
-	fmt.Printf("%s\n", iter.Count())
+	fmt.Printf("%s\n", iter.CountIter{})
 
 	// Output:
 	// Iterator<Count>
@@ -40,4 +40,5 @@ func TestCount(t *testing.T) {
 func TestCount_String(t *testing.T) {
 	counter := iter.Count()
 	assert.Equal(t, counter.String(), "Iterator<Count>")
+	assert.Equal(t, iter.CountIter{}.String(), "Iterator<Count>")
 }

--- a/iter/counter_test.go
+++ b/iter/counter_test.go
@@ -20,9 +20,24 @@ func ExampleCount() {
 	// Some(2)
 }
 
+func ExampleCountIter_String() {
+	counter := iter.Count()
+	fmt.Println(counter)
+	fmt.Printf("%s\n", iter.Count())
+
+	// Output:
+	// Iterator<Count>
+	// Iterator<Count>
+}
+
 func TestCount(t *testing.T) {
 	counter := iter.Count()
 	assert.Equal(t, counter.Next().Unwrap(), 0)
 	assert.Equal(t, counter.Next().Unwrap(), 1)
 	assert.Equal(t, counter.Next().Unwrap(), 2)
+}
+
+func TestCount_String(t *testing.T) {
+	counter := iter.Count()
+	assert.Equal(t, counter.String(), "Iterator<Count>")
 }


### PR DESCRIPTION
**Please provide a brief description of the change.**

This PR addresses `fmt.Stringer` implementation for `iter.CountIter`, in other PRs I'll address the `fmt.Stringer` for other iterators.

**Which issue does this change relate to?**

https://github.com/BooleanCat/go-functional/issues/81

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] My code is formatted (`make check`)
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies