### PR TITLE
Support Stringer for ChainIter and MapIter

### DIFF
--- a/iter/chain.go
+++ b/iter/chain.go
@@ -1,6 +1,11 @@
 package iter
 
-import "github.com/BooleanCat/go-functional/option"
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/BooleanCat/go-functional/option"
+)
 
 // ChainIter iterator, see [Chain].
 type ChainIter[T any] struct {
@@ -30,7 +35,15 @@ func (iter *ChainIter[T]) Next() option.Option[T] {
 
 		iter.iteratorIndex++
 	}
-
 }
 
-var _ Iterator[struct{}] = new(ChainIter[struct{}])
+// String implements the [fmt.Stringer] interface
+func (c ChainIter[T]) String() string {
+	var instanceOfT T
+	return fmt.Sprintf("Iterator<Chain, type=%s>", reflect.TypeOf(instanceOfT))
+}
+
+var (
+	_ fmt.Stringer       = new(ChainIter[struct{}])
+	_ Iterator[struct{}] = new(ChainIter[struct{}])
+)

--- a/iter/chain_test.go
+++ b/iter/chain_test.go
@@ -19,6 +19,11 @@ func ExampleChain_method() {
 	// Output: [1 2 3 4 0 9]
 }
 
+func ExampleChainIter_String() {
+	fmt.Println(iter.Chain[int]())
+	// Output: Iterator<Chain, type=int>
+}
+
 func TestChainMultiple(t *testing.T) {
 	items := iter.Chain[int](iter.Lift([]int{1, 2}), iter.Lift([]int{3, 4}))
 	assert.Equal(t, items.Next().Unwrap(), 1)
@@ -48,4 +53,8 @@ func TestChainExhausted(t *testing.T) {
 	assert.True(t, iter.Next().IsNone())
 	assert.Equal(t, delegate1.NextCallCount(), 1)
 	assert.Equal(t, delegate2.NextCallCount(), 1)
+}
+
+func TestChainString(t *testing.T) {
+	assert.Equal(t, iter.Chain[int]().String(), "Iterator<Chain, type=int>")
 }

--- a/iter/counter.go
+++ b/iter/counter.go
@@ -32,5 +32,7 @@ func (c CountIter) String() string {
 	return "Iterator<Count>"
 }
 
-var _ fmt.Stringer = new(CountIter)
-var _ Iterator[int] = new(CountIter)
+var (
+	_ fmt.Stringer  = new(CountIter)
+	_ Iterator[int] = new(CountIter)
+)

--- a/iter/map.go
+++ b/iter/map.go
@@ -1,6 +1,11 @@
 package iter
 
-import "github.com/BooleanCat/go-functional/option"
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/BooleanCat/go-functional/option"
+)
 
 // MapIter iterator, see [Map].
 type MapIter[T, U any] struct {
@@ -47,4 +52,13 @@ func (iter *MapIter[T, U]) Next() option.Option[U] {
 	return option.Some(iter.fun(value))
 }
 
-var _ Iterator[struct{}] = new(MapIter[struct{}, struct{}])
+// String implements the [fmt.Stringer] interface
+func (iter MapIter[T, U]) String() string {
+	var instanceOfU U
+	return fmt.Sprintf("Iterator<Map, type=%s>", reflect.TypeOf(instanceOfU))
+}
+
+var (
+	_ fmt.Stringer       = new(MapIter[struct{}, struct{}])
+	_ Iterator[struct{}] = new(MapIter[struct{}, struct{}])
+)

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -2,6 +2,7 @@ package iter_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/BooleanCat/go-functional/internal/assert"
@@ -24,6 +25,11 @@ func ExampleTransform() {
 
 	fmt.Println(numbers)
 	// Output: [2 3 4]
+}
+
+func ExampleMapIter_String() {
+	fmt.Println(iter.Map[int, string](iter.Count(), strconv.Itoa))
+	// Output: Iterator<Map, type=string>
 }
 
 func ExampleTransform_method() {
@@ -60,4 +66,12 @@ func TestTransform(t *testing.T) {
 	numbers := iter.Transform[int](iter.Count(), addTwo).Take(3).Collect()
 
 	assert.SliceEqual[int](t, numbers, []int{2, 3, 4})
+}
+
+func TestMapIter_String(t *testing.T) {
+	assert.Equal(
+		t,
+		iter.Map[int, string](iter.Count(), strconv.Itoa).String(),
+		"Iterator<Map, type=string>",
+	)
 }


### PR DESCRIPTION
**Please provide a brief description of the change.**

Support Stringer representation for `ChainIter` and `MapIter`. This PR is a demonstration of the general pattern of string representations for Iterators that yield generic values (unlike `Counter` that always yields an `int`).

**Which issue does this change relate to?**

#81 

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
