### PR TITLE
Implement tee for iterators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .phony: test check lint
+.DEFAULT_GOAL := test
 
 check: lint
 	@go vet ./...

--- a/internal/utils.go/min.go
+++ b/internal/utils.go/min.go
@@ -1,0 +1,11 @@
+package utils
+
+import "github.com/BooleanCat/go-functional/constraints"
+
+func Min[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return a
+	}
+
+	return b
+}

--- a/internal/utils.go/min_test.go
+++ b/internal/utils.go/min_test.go
@@ -1,0 +1,14 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/BooleanCat/go-functional/internal/assert"
+	"github.com/BooleanCat/go-functional/internal/utils.go"
+)
+
+func TestMin(t *testing.T) {
+	assert.Equal(t, utils.Min(1, 2), 1)
+	assert.Equal(t, utils.Min(2, 1), 1)
+	assert.Equal(t, utils.Min(1, 1), 1)
+}

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -160,3 +160,9 @@ func (iter *BaseIter[T]) Transform(op func(T) T) *MapIter[T, T] {
 func (iter *BaseIter[T]) Exclude(fun func(T) bool) *FilterIter[T] {
 	return Exclude[T](iter, fun)
 }
+
+// Tee is a convenience method for [Tee], providing this iterator as an
+// argument.
+func (iter *BaseIter[T]) Tee() *TeeIters[T] {
+	return Tee[T](iter)
+}

--- a/iter/tee.go
+++ b/iter/tee.go
@@ -1,0 +1,106 @@
+package iter
+
+import (
+	"sync"
+
+	"github.com/BooleanCat/go-functional/internal/utils.go"
+	"github.com/BooleanCat/go-functional/option"
+)
+
+// TeeIters, see [Tee].
+type TeeIters[T any] struct {
+	iter      Iterator[T]
+	One       *TeeIterOutput[T]
+	Two       *TeeIterOutput[T]
+	buffer    []T
+	lock      sync.Mutex
+	oneIndex  int
+	twoIndex  int
+	exhausted bool
+}
+
+// Tee instantiates a [*TeeIters] that provides two iterators that yield all
+// items from the provided iterator. The two iterators are independent, so
+// consuming one will not affect the other.
+//
+// It is safe to consume the two iterators in parallel.
+func Tee[T any](iter Iterator[T]) *TeeIters[T] {
+	teeIter := &TeeIters[T]{iter: iter}
+
+	one := &TeeIterOutput[T]{tee: teeIter, id: 1}
+	one.BaseIter = BaseIter[T]{one}
+
+	two := &TeeIterOutput[T]{tee: teeIter, id: 2}
+	two.BaseIter = BaseIter[T]{two}
+
+	teeIter.One = one
+	teeIter.Two = two
+
+	return teeIter
+}
+
+func (iter *TeeIters[T]) take(id int) option.Option[T] {
+	iter.lock.Lock()
+	defer iter.lock.Unlock()
+
+	if iter.oneIndex > 0 && iter.twoIndex > 0 {
+		smaller := utils.Min(iter.oneIndex, iter.twoIndex)
+		iter.oneIndex -= smaller
+		iter.twoIndex -= smaller
+		iter.buffer = iter.buffer[smaller:]
+	}
+
+	if id == 1 {
+		if iter.oneIndex < len(iter.buffer) {
+			next := iter.buffer[iter.oneIndex]
+			iter.oneIndex++
+			return option.Some(next)
+		}
+
+		if iter.exhausted && len(iter.buffer) == 0 {
+			return option.None[T]()
+		}
+
+		if next := iter.iter.Next(); next.IsSome() {
+			iter.buffer = append(iter.buffer, next.Unwrap())
+			iter.oneIndex++
+			return next
+		}
+
+		iter.exhausted = true
+
+		return option.None[T]()
+	}
+
+	if iter.twoIndex < len(iter.buffer) {
+		next := iter.buffer[iter.twoIndex]
+		iter.twoIndex++
+		return option.Some(next)
+	}
+
+	if iter.exhausted && len(iter.buffer) == 0 {
+		return option.None[T]()
+	}
+
+	if next := iter.iter.Next(); next.IsSome() {
+		iter.buffer = append(iter.buffer, next.Unwrap())
+		iter.twoIndex++
+		return next
+	}
+
+	iter.exhausted = true
+
+	return option.None[T]()
+}
+
+// TeeIterOutput iterator, see [Tee].
+type TeeIterOutput[T any] struct {
+	BaseIter[T]
+	tee *TeeIters[T]
+	id  int
+}
+
+// Next implements the [Iterator] interface.
+func (iter *TeeIterOutput[T]) Next() option.Option[T] {
+	return iter.tee.take(iter.id)
+}

--- a/iter/tee_test.go
+++ b/iter/tee_test.go
@@ -1,0 +1,61 @@
+package iter_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/BooleanCat/go-functional/internal/assert"
+	"github.com/BooleanCat/go-functional/internal/fakes"
+	"github.com/BooleanCat/go-functional/iter"
+)
+
+func TestTee(t *testing.T) {
+	numbers := iter.Count().Take(3)
+	iters := numbers.Tee()
+
+	assert.SliceEqual[int](t, iters.One.Collect(), []int{0, 1, 2})
+	assert.SliceEqual[int](t, iters.Two.Collect(), []int{0, 1, 2})
+}
+
+func TestTeeTwoTakesFirst(t *testing.T) {
+	numbers := iter.Count().Take(3)
+	iters := numbers.Tee()
+
+	assert.SliceEqual[int](t, iters.Two.Collect(), []int{0, 1, 2})
+	assert.SliceEqual[int](t, iters.One.Collect(), []int{0, 1, 2})
+}
+
+func TestTeeEmpty(t *testing.T) {
+	iters := iter.Exhausted[int]().Tee()
+
+	assert.Empty[int](t, iters.One.Collect())
+	assert.Empty[int](t, iters.Two.Collect())
+}
+
+func TestTeeParallel(t *testing.T) {
+	iters := iter.Count().Take(100000).Tee()
+
+	wait := sync.WaitGroup{}
+	wait.Add(2)
+
+	go func() {
+		defer wait.Done()
+		assert.SliceEqual[int](t, iters.One.Collect(), iter.Count().Take(100000).Collect())
+	}()
+
+	go func() {
+		defer wait.Done()
+		assert.SliceEqual[int](t, iters.Two.Collect(), iter.Count().Take(100000).Collect())
+	}()
+
+	wait.Wait()
+}
+
+func TestTeeExhausted(t *testing.T) {
+	delegate := new(fakes.Iterator[int])
+	iters := iter.Take[int](delegate, 10).Tee()
+
+	assert.Empty[int](t, iters.One.Collect())
+	assert.Empty[int](t, iters.Two.Collect())
+	assert.Equal(t, delegate.NextCallCount(), 1)
+}


### PR DESCRIPTION
**Please provide a brief description of the change.**

Support `tee` behaviour for iterators.

**Which issue does this change relate to?**

#88 

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] My code is formatted (`make check`)
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies