### PR TITLE
Disable caching in Go action in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-        with: { go-version: "1.21" }
+        with:
+          go-version: "1.21"
+          cache: false
       - run: make check
         env: { SKIP_LINT: true }
       - uses: golangci/golangci-lint-action@v3
@@ -25,5 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-        with: { go-version: "${{ matrix.go-version }}" }
+        with:
+          go-version: "${{ matrix.go-version }}"
+          cache: false
       - run: make test


### PR DESCRIPTION
**Please provide a brief description of the change.**

Actions is spitting out warnings about caching not working because there's no `go.sum` file. This makes sense because there are no dependencies. To remove this noisy warning caching is disabled.

**Which issue does this change relate to?**

None.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
