### PR TITLE
Test with go1.22 release candidate in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go-version: ["1.20", "1.21"]
+        go-version: ["1.20", "1.21", "1.22.0-rc.2"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**Please provide a brief description of the change.**

In order to head up any compatibility issues with Go 1.22, start testing with the release candidate.

**Which issue does this change relate to?**

N/A.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies

**Additional context**

_Add any other context about the problem here._
