### PR TITLE
Adapt project to current 1.23 iter API

### DIFF
--- a/future/maps/maps.go
+++ b/future/maps/maps.go
@@ -1,0 +1,18 @@
+// Package maps provides early implementations of map-related functions
+// available in Go 1.23+.
+package maps
+
+import "iter"
+
+// All returns an iterator over key-value pairs from m. The iteration order is
+// not specified and is not guaranteed to be the same from one call to the
+// next.
+func All[Map ~map[K]V, K comparable, V any](m Map) iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for key, value := range m {
+			if !yield(key, value) {
+				return
+			}
+		}
+	}
+}

--- a/future/maps/maps.go
+++ b/future/maps/maps.go
@@ -16,3 +16,14 @@ func All[Map ~map[K]V, K comparable, V any](m Map) iter.Seq2[K, V] {
 		}
 	}
 }
+
+// Collect collects key-value pairs from seq into a new map and returns it.
+func Collect[K comparable, V any](seq iter.Seq2[K, V]) map[K]V {
+	m := make(map[K]V)
+
+	for key, value := range seq {
+		m[key] = value
+	}
+
+	return m
+}

--- a/future/maps/maps_test.go
+++ b/future/maps/maps_test.go
@@ -44,9 +44,7 @@ func TestAll(t *testing.T) {
 func TestAllEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range maps.All(map[int]string{}) {
-		t.Error("unexpected")
-	}
+	assert.Equal(t, len(maps.Collect(maps.All(map[int]string{}))), 0)
 }
 
 func TestAllTerminateEarly(t *testing.T) {
@@ -54,4 +52,20 @@ func TestAllTerminateEarly(t *testing.T) {
 
 	_, stop := iter.Pull2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"}))
 	stop()
+}
+
+func ExampleCollect() {
+	numbers := maps.Collect(maps.All(map[int]string{1: "one", 2: "two"}))
+
+	fmt.Println(numbers[0])
+	fmt.Println(numbers[1])
+	// Output
+	// one
+	// two
+}
+
+func TestCollectEmpty(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, len(maps.Collect(maps.All(map[int]string{}))), 0)
 }

--- a/future/maps/maps_test.go
+++ b/future/maps/maps_test.go
@@ -1,0 +1,57 @@
+package maps_test
+
+import (
+	"fmt"
+	"iter"
+	"sort"
+	"testing"
+
+	"github.com/BooleanCat/go-functional/v2/future/maps"
+	"github.com/BooleanCat/go-functional/v2/internal/assert"
+)
+
+func ExampleAll() {
+	for key, value := range maps.All(map[int]string{1: "one", 2: "two", 3: "three"}) {
+		fmt.Println(key, value)
+	}
+}
+
+type keyValuePair[K comparable, V any] struct {
+	key   K
+	value V
+}
+
+func TestAll(t *testing.T) {
+	t.Parallel()
+
+	values := make([]keyValuePair[int, string], 0, 3)
+
+	for key, value := range maps.All(map[int]string{1: "one", 2: "two", 3: "three"}) {
+		values = append(values, keyValuePair[int, string]{key, value})
+	}
+
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].key < values[j].key
+	})
+
+	assert.SliceEqual(t, values, []keyValuePair[int, string]{
+		{1, "one"},
+		{2, "two"},
+		{3, "three"},
+	})
+}
+
+func TestAllEmpty(t *testing.T) {
+	t.Parallel()
+
+	for _, _ = range maps.All(map[int]string{}) {
+		t.Error("unexpected")
+	}
+}
+
+func TestAllTerminateEarly(t *testing.T) {
+	t.Parallel()
+
+	_, stop := iter.Pull2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"}))
+	stop()
+}

--- a/future/maps/maps_test.go
+++ b/future/maps/maps_test.go
@@ -64,6 +64,15 @@ func ExampleCollect() {
 	// two
 }
 
+func TestCollect(t *testing.T) {
+	t.Parallel()
+
+	numbers := maps.Collect(maps.All(map[int]string{1: "one", 2: "two"}))
+
+	assert.Equal(t, numbers[1], "one")
+	assert.Equal(t, numbers[2], "two")
+}
+
 func TestCollectEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/future/slices/slices.go
+++ b/future/slices/slices.go
@@ -1,0 +1,27 @@
+// Package slices provides early implementations of slice-related functions
+// available in Go 1.23+.
+package slices
+
+import "iter"
+
+// Values returns an iterator over the slice elements, starting with s[0].
+func Values[Slice ~[]E, E any](slice Slice) iter.Seq[E] {
+	return func(yield func(E) bool) {
+		for _, value := range slice {
+			if !yield(value) {
+				return
+			}
+		}
+	}
+}
+
+// Collect collects values from seq into a new slice and returns it.
+func Collect[E any](seq iter.Seq[E]) []E {
+	slice := make([]E, 0)
+
+	for item := range seq {
+		slice = append(slice, item)
+	}
+
+	return slice
+}

--- a/future/slices/slices_test.go
+++ b/future/slices/slices_test.go
@@ -1,0 +1,47 @@
+package slices_test
+
+import (
+	"fmt"
+	"iter"
+	"testing"
+
+	"github.com/BooleanCat/go-functional/v2/future/slices"
+	"github.com/BooleanCat/go-functional/v2/internal/assert"
+)
+
+func ExampleValues() {
+	for number := range slices.Values([]int{1, 2, 3}) {
+		fmt.Println(number)
+	}
+
+	// Output:
+	// 1
+	// 2
+	// 3
+}
+
+func TestValuesEmpty(t *testing.T) {
+	t.Parallel()
+
+	for number := range slices.Values([]int{}) {
+		t.Error("unexpected", number)
+	}
+}
+
+func TestValuesTerminateEarly(t *testing.T) {
+	t.Parallel()
+
+	_, stop := iter.Pull(slices.Values([]int{1, 2, 3}))
+	stop()
+}
+
+func ExampleCollect() {
+	fmt.Println(slices.Collect(slices.Values([]int{1, 2, 3})))
+	// Output: [1 2 3]
+}
+
+func TestCollectEmpty(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty[int](t, slices.Collect(slices.Values([]int{})))
+}

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -65,7 +65,7 @@ func EqualElements[T comparable](t *testing.T, a, b []T) {
 	}
 }
 
-func Empty[S any, T []S | ~string](t *testing.T, items T) {
+func Empty[E any, Slice ~[]E | ~string](t *testing.T, items Slice) {
 	t.Helper()
 
 	if len(items) != 0 {

--- a/iter/count.go
+++ b/iter/count.go
@@ -3,12 +3,12 @@ package iter
 import "iter"
 
 // Count yields all non-negative integers in ascending order.
-func Count() Iterator[int] {
-	return Iterator[int](iter.Seq[int](func(yield func(int) bool) {
+func Count() iter.Seq[int] {
+	return func(yield func(int) bool) {
 		for i := 0; ; i++ {
 			if !yield(i) {
 				return
 			}
 		}
-	}))
+	}
 }

--- a/iter/count.go
+++ b/iter/count.go
@@ -3,12 +3,15 @@ package iter
 import "iter"
 
 // Count yields all non-negative integers in ascending order.
-func Count() iter.Seq[int] {
-	return func(yield func(int) bool) {
-		for i := 0; ; i++ {
+func Count[V ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~int | ~int8 | ~int16 | ~int32 | ~int64]() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		var i V
+
+		for {
 			if !yield(i) {
 				return
 			}
+			i++
 		}
 	}
 }

--- a/iter/count_test.go
+++ b/iter/count_test.go
@@ -26,6 +26,6 @@ func ExampleCount() {
 func TestCountTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(it.Seq[int](iter.Count()))
+	_, stop := it.Pull(iter.Count())
 	stop()
 }

--- a/iter/count_test.go
+++ b/iter/count_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleCount() {
-	for i := range iter.Count() {
+	for i := range iter.Count[int]() {
 		if i >= 3 {
 			break
 		}
@@ -26,6 +26,6 @@ func ExampleCount() {
 func TestCountTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(iter.Count())
+	_, stop := it.Pull(iter.Count[int]())
 	stop()
 }

--- a/iter/drop.go
+++ b/iter/drop.go
@@ -21,5 +21,5 @@ func Drop[V any](delegate iter.Seq[V], count int) iter.Seq[V] {
 
 // Drop is a convenience method for chaining [Drop] on [Iterator]s.
 func (iterator Iterator[V]) Drop(count int) Iterator[V] {
-	return Iterator[V](Drop[V](iter.Seq[V](iterator), count))
+	return Iterator[V](Drop(iter.Seq[V](iterator), count))
 }

--- a/iter/drop.go
+++ b/iter/drop.go
@@ -4,8 +4,8 @@ import "iter"
 
 // Drop yields all values from a delegate [Iterator] except the first `count`
 // values.
-func Drop[V any](delegate Iterator[V], count int) Iterator[V] {
-	return Iterator[V](iter.Seq[V](func(yield func(V) bool) {
+func Drop[V any](delegate iter.Seq[V], count int) iter.Seq[V] {
+	return func(yield func(V) bool) {
 		for value := range delegate {
 			if count > 0 {
 				count--
@@ -16,10 +16,10 @@ func Drop[V any](delegate Iterator[V], count int) Iterator[V] {
 				return
 			}
 		}
-	}))
+	}
 }
 
 // Drop is a convenience method for chaining [Drop] on [Iterator]s.
-func (iter Iterator[V]) Drop(count int) Iterator[V] {
-	return Drop[V](iter, count)
+func (iterator Iterator[V]) Drop(count int) Iterator[V] {
+	return Iterator[V](Drop[V](iter.Seq[V](iterator), count))
 }

--- a/iter/drop.go
+++ b/iter/drop.go
@@ -23,3 +23,25 @@ func Drop[V any](delegate iter.Seq[V], count int) iter.Seq[V] {
 func (iterator Iterator[V]) Drop(count int) Iterator[V] {
 	return Iterator[V](Drop(iter.Seq[V](iterator), count))
 }
+
+// Drop2 yields all pairs of values from a delegate [Iterator2] except the
+// first `count` pairs.
+func Drop2[V, W any](delegate iter.Seq2[V, W], count int) iter.Seq2[V, W] {
+	return func(yield func(V, W) bool) {
+		for v, w := range delegate {
+			if count > 0 {
+				count--
+				continue
+			}
+
+			if !yield(v, w) {
+				return
+			}
+		}
+	}
+}
+
+// Drop is a convenience method for chaining [Drop] on [Iterator2]s.
+func (iterator Iterator2[V, W]) Drop(count int) Iterator2[V, W] {
+	return Iterator2[V, W](Drop2(iter.Seq2[V, W](iterator), count))
+}

--- a/iter/drop_test.go
+++ b/iter/drop_test.go
@@ -3,8 +3,10 @@ package iter_test
 import (
 	"fmt"
 	it "iter"
+	sl "slices"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/maps"
 	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
@@ -43,4 +45,54 @@ func TestDropEmpty(t *testing.T) {
 	t.Parallel()
 
 	assert.Empty[int](t, slices.Collect(iter.Drop(slices.Values([]int{}), 2)))
+}
+
+func ExampleDrop2() {
+	numbers := maps.Collect(iter.Drop2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"}), 1))
+
+	fmt.Println(len(numbers))
+	// Output: 2
+}
+
+func ExampleDrop2_method() {
+	numbers := iter.Iterator2[int, string](maps.All(map[int]string{1: "one", 2: "two", 3: "three"})).Drop(1)
+
+	fmt.Println(len(maps.Collect(it.Seq2[int, string](numbers))))
+	// Output: 2
+}
+
+func TestDrop2(t *testing.T) {
+	t.Parallel()
+
+	keys := []int{1, 2, 3}
+	values := []string{"one", "two", "three"}
+
+	numbers := maps.Collect(iter.Drop2(iter.Zip(slices.Values(keys), slices.Values(values)), 1))
+
+	assert.Equal(t, len(numbers), 2)
+
+	for key := range numbers {
+		assert.True(t, sl.Contains(keys, key))
+	}
+}
+
+func TestDrop2Empty(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, len(maps.Collect(iter.Drop2(maps.All(map[int]string{}), 1))), 0)
+}
+
+func TestDrop2Zero(t *testing.T) {
+	t.Parallel()
+
+	numbers := maps.Collect(iter.Drop2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"}), 0))
+
+	assert.Equal(t, len(numbers), 3)
+}
+
+func TestDrop2TerminateEarly(t *testing.T) {
+	t.Parallel()
+
+	_, stop := it.Pull2(iter.Drop2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"}), 1))
+	stop()
 }

--- a/iter/drop_test.go
+++ b/iter/drop_test.go
@@ -5,11 +5,12 @@ import (
 	it "iter"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/iter"
 )
 
 func ExampleDrop() {
-	for value := range iter.Drop(iter.Lift([]int{1, 2, 3, 4, 5}), 2) {
+	for value := range iter.Drop(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})), 2) {
 		fmt.Println(value)
 	}
 
@@ -20,7 +21,7 @@ func ExampleDrop() {
 }
 
 func ExampleDrop_method() {
-	for value := range iter.Lift([]int{1, 2, 3, 4, 5}).Drop(2) {
+	for value := range iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})).Drop(2) {
 		fmt.Println(value)
 	}
 
@@ -33,14 +34,14 @@ func ExampleDrop_method() {
 func TestDropTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(it.Seq[int](iter.Drop(iter.Lift([]int{1, 2, 3}), 2)))
+	_, stop := it.Pull(it.Seq[int](iter.Drop(iter.Iterator[int](slices.Values([]int{1, 2, 3})), 2)))
 	stop()
 }
 
 func TestDropEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Drop(iter.Lift([]int{}), 2) {
+	for _ = range iter.Drop(iter.Iterator[int](slices.Values([]int{})), 2) {
 		t.Error("unexpected")
 	}
 }

--- a/iter/drop_test.go
+++ b/iter/drop_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleDrop() {
-	for value := range iter.Drop(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})), 2) {
+	for value := range iter.Drop(slices.Values([]int{1, 2, 3, 4, 5}), 2) {
 		fmt.Println(value)
 	}
 
@@ -34,14 +34,14 @@ func ExampleDrop_method() {
 func TestDropTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(it.Seq[int](iter.Drop(iter.Iterator[int](slices.Values([]int{1, 2, 3})), 2)))
+	_, stop := it.Pull(iter.Drop(slices.Values([]int{1, 2, 3}), 2))
 	stop()
 }
 
 func TestDropEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Drop(iter.Iterator[int](slices.Values([]int{})), 2) {
+	for _ = range iter.Drop(slices.Values([]int{}), 2) {
 		t.Error("unexpected")
 	}
 }

--- a/iter/drop_test.go
+++ b/iter/drop_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/BooleanCat/go-functional/v2/future/slices"
+	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
 )
 
@@ -41,7 +42,5 @@ func TestDropTerminateEarly(t *testing.T) {
 func TestDropEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Drop(slices.Values([]int{}), 2) {
-		t.Error("unexpected")
-	}
+	assert.Empty[int](t, slices.Collect(iter.Drop(slices.Values([]int{}), 2)))
 }

--- a/iter/enumerate.go
+++ b/iter/enumerate.go
@@ -3,9 +3,9 @@ package iter
 import "iter"
 
 // Enumerate yields pairs of indices and values from an iterator.
-func Enumerate[V any](delegate Iterator[V]) Iterator2[int, V] {
-	return Iterator2[int, V](iter.Seq2[int, V](func(yield func(int, V) bool) {
-		delegate, stop := iter.Pull(iter.Seq[V](delegate))
+func Enumerate[V any](delegate iter.Seq[V]) iter.Seq2[int, V] {
+	return func(yield func(int, V) bool) {
+		delegate, stop := iter.Pull(delegate)
 		defer stop()
 
 		for i := 0; ; i++ {
@@ -15,10 +15,10 @@ func Enumerate[V any](delegate Iterator[V]) Iterator2[int, V] {
 				return
 			}
 		}
-	}))
+	}
 }
 
 // Enumerate is a convenience method for chaining [Enumerate] on [Iterator]s.
-func (iter Iterator[V]) Enumerate() Iterator2[int, V] {
-	return Enumerate[V](iter)
+func (iterator Iterator[V]) Enumerate() Iterator2[int, V] {
+	return Iterator2[int, V](Enumerate[V](iter.Seq[V](iterator)))
 }

--- a/iter/enumerate_test.go
+++ b/iter/enumerate_test.go
@@ -5,11 +5,12 @@ import (
 	it "iter"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/iter"
 )
 
 func ExampleEnumerate() {
-	for index, value := range iter.Enumerate(iter.Lift([]int{1, 2, 3})) {
+	for index, value := range iter.Enumerate(iter.Iterator[int](slices.Values([]int{1, 2, 3}))) {
 		fmt.Println(index, value)
 	}
 
@@ -20,7 +21,7 @@ func ExampleEnumerate() {
 }
 
 func ExampleEnumerate_method() {
-	for index, value := range iter.Lift([]int{1, 2, 3}).Enumerate() {
+	for index, value := range iter.Iterator[int](slices.Values([]int{1, 2, 3})).Enumerate() {
 		fmt.Println(index, value)
 	}
 
@@ -33,6 +34,6 @@ func ExampleEnumerate_method() {
 func TestEnumerateTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(it.Seq2[int, int](iter.Enumerate(iter.Lift([]int{1, 2}))))
+	_, stop := it.Pull2(it.Seq2[int, int](iter.Enumerate(iter.Iterator[int](slices.Values([]int{1, 2})))))
 	stop()
 }

--- a/iter/enumerate_test.go
+++ b/iter/enumerate_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleEnumerate() {
-	for index, value := range iter.Enumerate(iter.Iterator[int](slices.Values([]int{1, 2, 3}))) {
+	for index, value := range iter.Enumerate(slices.Values([]int{1, 2, 3})) {
 		fmt.Println(index, value)
 	}
 
@@ -34,6 +34,6 @@ func ExampleEnumerate_method() {
 func TestEnumerateTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(it.Seq2[int, int](iter.Enumerate(iter.Iterator[int](slices.Values([]int{1, 2})))))
+	_, stop := it.Pull2(iter.Enumerate(slices.Values([]int{1, 2})))
 	stop()
 }

--- a/iter/filter.go
+++ b/iter/filter.go
@@ -69,12 +69,12 @@ func Exclude2[V, W any](delegate iter.Seq2[V, W], predicate func(V, W) bool) ite
 	}
 }
 
-// Filter2 is a convenience method for chaining [Filter2] on [Iterator2]s.
-func (iterator Iterator2[V, W]) Filter2(predicate func(V, W) bool) Iterator2[V, W] {
+// Filter is a convenience method for chaining [Filter] on [Iterator2]s.
+func (iterator Iterator2[V, W]) Filter(predicate func(V, W) bool) Iterator2[V, W] {
 	return Iterator2[V, W](Filter2[V, W](iter.Seq2[V, W](iterator), predicate))
 }
 
-// Exclude2 is a convenience method for chaining [Exclude2] on [Iterator2]s.
-func (iterator Iterator2[V, W]) Exclude2(predicate func(V, W) bool) Iterator2[V, W] {
+// Exclude is a convenience method for chaining [Exclude] on [Iterator2]s.
+func (iterator Iterator2[V, W]) Exclude(predicate func(V, W) bool) Iterator2[V, W] {
 	return Iterator2[V, W](Exclude2[V, W](iter.Seq2[V, W](iterator), predicate))
 }

--- a/iter/filter.go
+++ b/iter/filter.go
@@ -7,9 +7,9 @@ import (
 )
 
 // Filter yields values from an iterator that satisfy a predicate.
-func Filter[V any](delegate Iterator[V], predicate func(V) bool) Iterator[V] {
-	return Iterator[V](iter.Seq[V](func(yield func(V) bool) {
-		delegate, stop := iter.Pull(iter.Seq[V](delegate))
+func Filter[V any](delegate iter.Seq[V], predicate func(V) bool) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		delegate, stop := iter.Pull(delegate)
 		defer stop()
 
 		for {
@@ -19,28 +19,28 @@ func Filter[V any](delegate Iterator[V], predicate func(V) bool) Iterator[V] {
 				return
 			}
 		}
-	}))
+	}
 }
 
 // Exclude yields values from an iterator that do not satisfy a predicate.
-func Exclude[V any](delegate Iterator[V], predicate func(V) bool) Iterator[V] {
-	return delegate.Filter(filter.Not[V](predicate))
+func Exclude[V any](delegate iter.Seq[V], predicate func(V) bool) iter.Seq[V] {
+	return Filter[V](delegate, filter.Not[V](predicate))
 }
 
 // Filter is a convenience method for chaining [Filter] on [Iterator]s.
-func (iter Iterator[V]) Filter(predicate func(V) bool) Iterator[V] {
-	return Filter[V](iter, predicate)
+func (iterator Iterator[V]) Filter(predicate func(V) bool) Iterator[V] {
+	return Iterator[V](Filter[V](iter.Seq[V](iterator), predicate))
 }
 
 // Exclude is a convenience method for chaining [Exclude] on [Iterator]s.
-func (iter Iterator[V]) Exclude(predicate func(V) bool) Iterator[V] {
-	return Exclude[V](iter, predicate)
+func (iterator Iterator[V]) Exclude(predicate func(V) bool) Iterator[V] {
+	return Iterator[V](Exclude[V](iter.Seq[V](iterator), predicate))
 }
 
 // Filter2 yields values from an iterator that satisfy a predicate.
-func Filter2[V, W any](delegate Iterator2[V, W], predicate func(V, W) bool) Iterator2[V, W] {
-	return Iterator2[V, W](iter.Seq2[V, W](func(yield func(V, W) bool) {
-		delegate, stop := iter.Pull2(iter.Seq2[V, W](delegate))
+func Filter2[V, W any](delegate iter.Seq2[V, W], predicate func(V, W) bool) iter.Seq2[V, W] {
+	return func(yield func(V, W) bool) {
+		delegate, stop := iter.Pull2(delegate)
 		defer stop()
 
 		for {
@@ -50,13 +50,13 @@ func Filter2[V, W any](delegate Iterator2[V, W], predicate func(V, W) bool) Iter
 				return
 			}
 		}
-	}))
+	}
 }
 
 // Exclude2 yields values from an iterator that do not satisfy a predicate.
-func Exclude2[V, W any](delegate Iterator2[V, W], predicate func(V, W) bool) Iterator2[V, W] {
-	return Iterator2[V, W](iter.Seq2[V, W](func(yield func(V, W) bool) {
-		delegate, stop := iter.Pull2(iter.Seq2[V, W](delegate))
+func Exclude2[V, W any](delegate iter.Seq2[V, W], predicate func(V, W) bool) iter.Seq2[V, W] {
+	return func(yield func(V, W) bool) {
+		delegate, stop := iter.Pull2(delegate)
 		defer stop()
 
 		for {
@@ -66,15 +66,15 @@ func Exclude2[V, W any](delegate Iterator2[V, W], predicate func(V, W) bool) Ite
 				return
 			}
 		}
-	}))
+	}
 }
 
 // Filter2 is a convenience method for chaining [Filter2] on [Iterator2]s.
-func (iter Iterator2[V, W]) Filter2(predicate func(V, W) bool) Iterator2[V, W] {
-	return Filter2[V, W](iter, predicate)
+func (iterator Iterator2[V, W]) Filter2(predicate func(V, W) bool) Iterator2[V, W] {
+	return Iterator2[V, W](Filter2[V, W](iter.Seq2[V, W](iterator), predicate))
 }
 
 // Exclude2 is a convenience method for chaining [Exclude2] on [Iterator2]s.
-func (iter Iterator2[V, W]) Exclude2(predicate func(V, W) bool) Iterator2[V, W] {
-	return Exclude2[V, W](iter, predicate)
+func (iterator Iterator2[V, W]) Exclude2(predicate func(V, W) bool) Iterator2[V, W] {
+	return Iterator2[V, W](Exclude2[V, W](iter.Seq2[V, W](iterator), predicate))
 }

--- a/iter/filter/filter.go
+++ b/iter/filter/filter.go
@@ -51,6 +51,16 @@ func LessThan[T cmp.Ordered](threshold T) func(T) bool {
 	}
 }
 
+// Passthrough returns a function that returns true for any value.
+func Passthrough[V any](value V) bool {
+	return true
+}
+
+// Passthrough2 returns a function that returns true for any pair of values.
+func Passthrough2[V any, W any](value1 V, value2 W) bool {
+	return true
+}
+
 // Not returns a function that inverts the result of the provided function.
 func Not[T any](fn func(T) bool) func(T) bool {
 	return func(value T) bool {

--- a/iter/filter/filter_test.go
+++ b/iter/filter/filter_test.go
@@ -3,56 +3,57 @@ package filter_test
 import (
 	"fmt"
 
+	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/iter"
 	"github.com/BooleanCat/go-functional/v2/iter/filter"
 )
 
 func ExampleIsEven() {
-	fmt.Println(iter.Lift([]int{1, 2, 3, 4}).Filter(filter.IsEven).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.IsEven).Collect())
 	// Output: [2 4]
 }
 
 func ExampleIsOdd() {
-	fmt.Println(iter.Lift([]int{1, 2, 3, 4}).Filter(filter.IsOdd).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.IsOdd).Collect())
 	// Output: [1 3]
 }
 
 func ExampleIsEqual() {
-	fmt.Println(iter.Lift([]int{1, 2, 3, 4}).Filter(filter.IsEqual(2)).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.IsEqual(2)).Collect())
 	// Output: [2]
 }
 
 func ExampleNotEqual() {
-	fmt.Println(iter.Lift([]int{1, 2, 3, 4}).Filter(filter.NotEqual(2)).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.NotEqual(2)).Collect())
 	// Output: [1 3 4]
 }
 
 func ExampleIsZero() {
-	fmt.Println(iter.Lift([]int{0, 1, 2, 3}).Filter(filter.IsZero).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{0, 1, 2, 3})).Filter(filter.IsZero).Collect())
 	// Output: [0]
 }
 
 func ExampleGreaterThan() {
-	fmt.Println(iter.Lift([]int{1, 2, 3, 4}).Filter(filter.GreaterThan(2)).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.GreaterThan(2)).Collect())
 	// Output: [3 4]
 }
 
 func ExampleLessThan() {
-	fmt.Println(iter.Lift([]int{1, 2, 3, 4}).Filter(filter.LessThan(3)).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.LessThan(3)).Collect())
 	// Output: [1 2]
 }
 
 func ExampleNot() {
-	fmt.Println(iter.Lift([]int{1, 2, 3, 4}).Filter(filter.Not[int](filter.IsEven)).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.Not[int](filter.IsEven)).Collect())
 	// Output: [1 3]
 }
 
 func ExampleAnd() {
-	fmt.Println(iter.Lift([]int{1, 2, 3, 4}).Filter(filter.And(filter.IsOdd, filter.GreaterThan(2))).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.And(filter.IsOdd, filter.GreaterThan(2))).Collect())
 	// Output: [3]
 }
 
 func ExampleOr() {
-	fmt.Println(iter.Lift([]int{1, 2, 3, 4}).Filter(filter.Or(filter.IsEven, filter.LessThan(3))).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.Or(filter.IsEven, filter.LessThan(3))).Collect())
 	// Output: [1 2 4]
 }

--- a/iter/filter/filter_test.go
+++ b/iter/filter/filter_test.go
@@ -3,6 +3,7 @@ package filter_test
 import (
 	"fmt"
 
+	"github.com/BooleanCat/go-functional/v2/future/maps"
 	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/iter"
 	"github.com/BooleanCat/go-functional/v2/iter/filter"
@@ -41,6 +42,20 @@ func ExampleGreaterThan() {
 func ExampleLessThan() {
 	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.LessThan(3)).Collect())
 	// Output: [1 2]
+}
+
+func ExamplePassthrough() {
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4})).Filter(filter.Passthrough).Collect())
+	// Output: [1 2 3 4]
+
+}
+
+func ExamplePassthrough2() {
+	numbers := maps.Collect(iter.Filter2(maps.All(map[int]string{1: "two"}), filter.Passthrough2))
+
+	fmt.Println(numbers[1])
+	// Output: two
+
 }
 
 func ExampleNot() {

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -92,18 +92,13 @@ func ExampleFilter2_method() {
 func TestFilter2Empty(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, len(maps.Collect(iter.Filter2(maps.All(map[int]string{}), func(int, string) bool {
-		return true
-	}))), 0)
+	assert.Equal(t, len(maps.Collect(iter.Filter2(maps.All(map[int]string{}), filter.Passthrough2))), 0)
 }
 
 func TestFilter2TerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(iter.Filter2(maps.All(map[int]string{
-		1: "one",
-		2: "two",
-	}), func(int, string) bool { return true }))
+	_, stop := it.Pull2(iter.Filter2(maps.All(map[int]string{1: "one", 2: "two"}), filter.Passthrough2))
 	stop()
 }
 
@@ -132,14 +127,12 @@ func ExampleExclude2_method() {
 func TestExclude2Empty(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, len(maps.Collect(iter.Exclude2(maps.All(map[int]string{}), func(int, string) bool {
-		return true
-	}))), 0)
+	assert.Equal(t, len(maps.Collect(iter.Exclude2(maps.All(map[int]string{}), filter.Passthrough2))), 0)
 }
 
 func TestExclude2TerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(iter.Exclude2(maps.All(map[int]string{}), func(int, string) bool { return true }))
+	_, stop := it.Pull2(iter.Exclude2(maps.All(map[int]string{}), filter.Passthrough2))
 	stop()
 }

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -82,7 +82,7 @@ func ExampleFilter2_method() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 2: "two", 3: "three"}
 
-	for key, value := range iter.Iterator2[int, string](maps.All(numbers)).Filter2(isOne) {
+	for key, value := range iter.Iterator2[int, string](maps.All(numbers)).Filter(isOne) {
 		fmt.Println(key, value)
 	}
 
@@ -117,7 +117,7 @@ func ExampleExclude2_method() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 3: "three"}
 
-	for key, value := range iter.Iterator2[int, string](maps.All(numbers)).Exclude2(isOne) {
+	for key, value := range iter.Iterator2[int, string](maps.All(numbers)).Exclude(isOne) {
 		fmt.Println(key, value)
 	}
 

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/BooleanCat/go-functional/v2/future/maps"
 	"github.com/BooleanCat/go-functional/v2/future/slices"
+	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
 	"github.com/BooleanCat/go-functional/v2/iter/filter"
 )
@@ -34,9 +35,7 @@ func ExampleFilter_method() {
 func TestFilterEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Filter(slices.Values([]int{}), filter.IsEven) {
-		t.Error("unexpected")
-	}
+	assert.Empty[int](t, slices.Collect(iter.Filter(slices.Values([]int{}), filter.IsEven)))
 }
 
 func TestFilterTerminateEarly(t *testing.T) {
@@ -93,9 +92,9 @@ func ExampleFilter2_method() {
 func TestFilter2Empty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range iter.Filter2(maps.All(map[int]string{}), func(int, string) bool { return true }) {
-		t.Error("unexpected")
-	}
+	assert.Equal(t, len(maps.Collect(iter.Filter2(maps.All(map[int]string{}), func(int, string) bool {
+		return true
+	}))), 0)
 }
 
 func TestFilter2TerminateEarly(t *testing.T) {
@@ -133,9 +132,9 @@ func ExampleExclude2_method() {
 func TestExclude2Empty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range iter.Exclude2(maps.All(map[int]string{}), func(int, string) bool { return true }) {
-		t.Error("unexpected")
-	}
+	assert.Equal(t, len(maps.Collect(iter.Exclude2(maps.All(map[int]string{}), func(int, string) bool {
+		return true
+	}))), 0)
 }
 
 func TestExclude2TerminateEarly(t *testing.T) {

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleFilter() {
-	for number := range iter.Filter(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})), filter.IsEven) {
+	for number := range iter.Filter(slices.Values([]int{1, 2, 3, 4, 5}), filter.IsEven) {
 		fmt.Println(number)
 	}
 
@@ -33,7 +33,7 @@ func ExampleFilter_method() {
 func TestFilterEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Filter(iter.Iterator[int](slices.Values([]int{})), filter.IsEven) {
+	for _ = range iter.Filter(slices.Values([]int{}), filter.IsEven) {
 		t.Error("unexpected")
 	}
 }
@@ -41,12 +41,12 @@ func TestFilterEmpty(t *testing.T) {
 func TestFilterTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(it.Seq[int](iter.Filter(iter.Iterator[int](slices.Values([]int{1, 2, 3})), filter.IsEven)))
+	_, stop := it.Pull(iter.Filter(slices.Values([]int{1, 2, 3}), filter.IsEven))
 	stop()
 }
 
 func ExampleExclude() {
-	for number := range iter.Exclude(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})), filter.IsEven) {
+	for number := range iter.Exclude(slices.Values([]int{1, 2, 3, 4, 5}), filter.IsEven) {
 		fmt.Println(number)
 	}
 
@@ -71,7 +71,7 @@ func ExampleFilter2() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 2: "two", 3: "three"}
 
-	for key, value := range iter.Filter2(iter.LiftHashMap(numbers), isOne) {
+	for key, value := range iter.Filter2(it.Seq2[int, string](iter.LiftHashMap(numbers)), isOne) {
 		fmt.Println(key, value)
 	}
 
@@ -92,7 +92,7 @@ func ExampleFilter2_method() {
 func TestFilter2Empty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range iter.Filter2(iter.LiftHashMap(map[int]string{}), func(int, string) bool { return true }) {
+	for _, _ = range iter.Filter2(it.Seq2[int, string](iter.LiftHashMap(map[int]string{})), func(int, string) bool { return true }) {
 		t.Error("unexpected")
 	}
 }
@@ -100,10 +100,10 @@ func TestFilter2Empty(t *testing.T) {
 func TestFilter2TerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(it.Seq2[int, string](iter.Filter2(iter.LiftHashMap(map[int]string{
+	_, stop := it.Pull2(iter.Filter2(it.Seq2[int, string](iter.LiftHashMap(map[int]string{
 		1: "one",
 		2: "two",
-	}), func(int, string) bool { return true })))
+	})), func(int, string) bool { return true }))
 	stop()
 }
 
@@ -111,7 +111,7 @@ func ExampleExclude2() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 3: "three"}
 
-	for key, value := range iter.Exclude2(iter.LiftHashMap(numbers), isOne) {
+	for key, value := range iter.Exclude2(it.Seq2[int, string](iter.LiftHashMap(numbers)), isOne) {
 		fmt.Println(key, value)
 	}
 
@@ -132,7 +132,7 @@ func ExampleExclude2_method() {
 func TestExclude2Empty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range iter.Exclude2(iter.LiftHashMap(map[int]string{}), func(int, string) bool { return true }) {
+	for _, _ = range iter.Exclude2(it.Seq2[int, string](iter.LiftHashMap(map[int]string{})), func(int, string) bool { return true }) {
 		t.Error("unexpected")
 	}
 }
@@ -140,6 +140,6 @@ func TestExclude2Empty(t *testing.T) {
 func TestExclude2TerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(it.Seq2[int, string](iter.Exclude2(iter.LiftHashMap(map[int]string{}), func(int, string) bool { return true })))
+	_, stop := it.Pull2(iter.Exclude2(it.Seq2[int, string](iter.LiftHashMap(map[int]string{})), func(int, string) bool { return true }))
 	stop()
 }

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -5,12 +5,13 @@ import (
 	it "iter"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/iter"
 	"github.com/BooleanCat/go-functional/v2/iter/filter"
 )
 
 func ExampleFilter() {
-	for number := range iter.Filter(iter.Lift([]int{1, 2, 3, 4, 5}), filter.IsEven) {
+	for number := range iter.Filter(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})), filter.IsEven) {
 		fmt.Println(number)
 	}
 
@@ -20,7 +21,7 @@ func ExampleFilter() {
 }
 
 func ExampleFilter_method() {
-	for number := range iter.Lift([]int{1, 2, 3, 4, 5}).Filter(filter.IsEven) {
+	for number := range iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})).Filter(filter.IsEven) {
 		fmt.Println(number)
 	}
 
@@ -32,7 +33,7 @@ func ExampleFilter_method() {
 func TestFilterEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Filter(iter.Lift([]int{}), filter.IsEven) {
+	for _ = range iter.Filter(iter.Iterator[int](slices.Values([]int{})), filter.IsEven) {
 		t.Error("unexpected")
 	}
 }
@@ -40,12 +41,12 @@ func TestFilterEmpty(t *testing.T) {
 func TestFilterTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(it.Seq[int](iter.Filter(iter.Lift([]int{1, 2, 3}), filter.IsEven)))
+	_, stop := it.Pull(it.Seq[int](iter.Filter(iter.Iterator[int](slices.Values([]int{1, 2, 3})), filter.IsEven)))
 	stop()
 }
 
 func ExampleExclude() {
-	for number := range iter.Exclude(iter.Lift([]int{1, 2, 3, 4, 5}), filter.IsEven) {
+	for number := range iter.Exclude(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})), filter.IsEven) {
 		fmt.Println(number)
 	}
 
@@ -56,7 +57,7 @@ func ExampleExclude() {
 }
 
 func ExampleExclude_method() {
-	for number := range iter.Lift([]int{1, 2, 3, 4, 5}).Exclude(filter.IsEven) {
+	for number := range iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})).Exclude(filter.IsEven) {
 		fmt.Println(number)
 	}
 

--- a/iter/filter_test.go
+++ b/iter/filter_test.go
@@ -5,6 +5,7 @@ import (
 	it "iter"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/maps"
 	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/iter"
 	"github.com/BooleanCat/go-functional/v2/iter/filter"
@@ -71,7 +72,7 @@ func ExampleFilter2() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 2: "two", 3: "three"}
 
-	for key, value := range iter.Filter2(it.Seq2[int, string](iter.LiftHashMap(numbers)), isOne) {
+	for key, value := range iter.Filter2(maps.All(numbers), isOne) {
 		fmt.Println(key, value)
 	}
 
@@ -82,7 +83,7 @@ func ExampleFilter2_method() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 2: "two", 3: "three"}
 
-	for key, value := range iter.LiftHashMap(numbers).Filter2(isOne) {
+	for key, value := range iter.Iterator2[int, string](maps.All(numbers)).Filter2(isOne) {
 		fmt.Println(key, value)
 	}
 
@@ -92,7 +93,7 @@ func ExampleFilter2_method() {
 func TestFilter2Empty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range iter.Filter2(it.Seq2[int, string](iter.LiftHashMap(map[int]string{})), func(int, string) bool { return true }) {
+	for _, _ = range iter.Filter2(maps.All(map[int]string{}), func(int, string) bool { return true }) {
 		t.Error("unexpected")
 	}
 }
@@ -100,10 +101,10 @@ func TestFilter2Empty(t *testing.T) {
 func TestFilter2TerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(iter.Filter2(it.Seq2[int, string](iter.LiftHashMap(map[int]string{
+	_, stop := it.Pull2(iter.Filter2(maps.All(map[int]string{
 		1: "one",
 		2: "two",
-	})), func(int, string) bool { return true }))
+	}), func(int, string) bool { return true }))
 	stop()
 }
 
@@ -111,7 +112,7 @@ func ExampleExclude2() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 3: "three"}
 
-	for key, value := range iter.Exclude2(it.Seq2[int, string](iter.LiftHashMap(numbers)), isOne) {
+	for key, value := range iter.Exclude2(maps.All(numbers), isOne) {
 		fmt.Println(key, value)
 	}
 
@@ -122,7 +123,7 @@ func ExampleExclude2_method() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 3: "three"}
 
-	for key, value := range iter.LiftHashMap(numbers).Exclude2(isOne) {
+	for key, value := range iter.Iterator2[int, string](maps.All(numbers)).Exclude2(isOne) {
 		fmt.Println(key, value)
 	}
 
@@ -132,7 +133,7 @@ func ExampleExclude2_method() {
 func TestExclude2Empty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range iter.Exclude2(it.Seq2[int, string](iter.LiftHashMap(map[int]string{})), func(int, string) bool { return true }) {
+	for _, _ = range iter.Exclude2(maps.All(map[int]string{}), func(int, string) bool { return true }) {
 		t.Error("unexpected")
 	}
 }
@@ -140,6 +141,6 @@ func TestExclude2Empty(t *testing.T) {
 func TestExclude2TerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(iter.Exclude2(it.Seq2[int, string](iter.LiftHashMap(map[int]string{})), func(int, string) bool { return true }))
+	_, stop := it.Pull2(iter.Exclude2(maps.All(map[int]string{}), func(int, string) bool { return true }))
 	stop()
 }

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -21,19 +21,6 @@ func (iterator Iterator[V]) Collect() []V {
 	return slices.Collect(iter.Seq[V](iterator))
 }
 
-// LiftHashMap yields all key-value pairs from a map.
-//
-// The order of iteration is non-deterministic.
-func LiftHashMap[K comparable, V any](m map[K]V) Iterator2[K, V] {
-	return Iterator2[K, V](iter.Seq2[K, V](func(yield func(K, V) bool) {
-		for key, value := range m {
-			if !yield(key, value) {
-				return
-			}
-		}
-	}))
-}
-
 // ForEach consumes an iterator and applies a function to each value yielded.
 func ForEach[V any](iter iter.Seq[V], fn func(V)) {
 	for item := range iter {

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -35,32 +35,32 @@ func LiftHashMap[K comparable, V any](m map[K]V) Iterator2[K, V] {
 }
 
 // ForEach consumes an iterator and applies a function to each value yielded.
-func ForEach[V any](iter Iterator[V], fn func(V)) {
+func ForEach[V any](iter iter.Seq[V], fn func(V)) {
 	for item := range iter {
 		fn(item)
 	}
 }
 
 // ForEach is a convenience method for chaining [ForEach] on [Iterator]s.
-func (iter Iterator[V]) ForEach(fn func(V)) {
-	ForEach[V](iter, fn)
+func (iterator Iterator[V]) ForEach(fn func(V)) {
+	ForEach(iter.Seq[V](iterator), fn)
 }
 
 // ForEach2 consumes an iterator and applies a function to each pair of values.
-func ForEach2[V, W any](iter Iterator2[V, W], fn func(V, W)) {
+func ForEach2[V, W any](iter iter.Seq2[V, W], fn func(V, W)) {
 	for v, w := range iter {
 		fn(v, w)
 	}
 }
 
 // ForEach2 is a convenience method for chaining [ForEach2] on [Iterator2]s.
-func (iter Iterator2[V, W]) ForEach2(fn func(V, W)) {
-	ForEach2[V, W](iter, fn)
+func (iterator Iterator2[V, W]) ForEach2(fn func(V, W)) {
+	ForEach2(iter.Seq2[V, W](iterator), fn)
 }
 
 // Reduce consumes an iterator and applies a function to each value yielded,
 // accumulating a single result.
-func Reduce[V any, R any](iter Iterator[V], fn func(R, V) R, initial R) R {
+func Reduce[V any, R any](iter iter.Seq[V], fn func(R, V) R, initial R) R {
 	result := initial
 
 	for item := range iter {
@@ -72,7 +72,7 @@ func Reduce[V any, R any](iter Iterator[V], fn func(R, V) R, initial R) R {
 
 // Reduce2 consumes an iterator and applies a function to each pair of values,
 // accumulating a single result.
-func Reduce2[V, W any, R any](iter Iterator2[V, W], fn func(R, V, W) R, initial R) R {
+func Reduce2[V, W any, R any](iter iter.Seq2[V, W], fn func(R, V, W) R, initial R) R {
 	result := initial
 
 	for v, w := range iter {

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -1,6 +1,10 @@
 package iter
 
-import "iter"
+import (
+	"iter"
+
+	"github.com/BooleanCat/go-functional/v2/future/slices"
+)
 
 type (
 	// Iterator is a wrapper around [iter.Seq] that allows for method chaining of
@@ -12,31 +16,9 @@ type (
 	Iterator2[V, W any] iter.Seq2[V, W]
 )
 
-// Lift yields all values from a slice.
-func Lift[V any](slice []V) Iterator[V] {
-	return Iterator[V](iter.Seq[V](func(yield func(V) bool) {
-		for _, value := range slice {
-			if !yield(value) {
-				return
-			}
-		}
-	}))
-}
-
-// Collect consumes an iterator and returns a slice of all values yielded.
-func Collect[V any](iter Iterator[V]) []V {
-	collection := make([]V, 0)
-
-	for item := range iter {
-		collection = append(collection, item)
-	}
-
-	return collection
-}
-
 // Collect is a convenience method for chaining [Collect] on [Iterator]s.
-func (iter Iterator[V]) Collect() []V {
-	return Collect[V](iter)
+func (iterator Iterator[V]) Collect() []V {
+	return slices.Collect(iter.Seq[V](iterator))
 }
 
 // LiftHashMap yields all key-value pairs from a map.

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -40,8 +40,8 @@ func ForEach2[V, W any](iter iter.Seq2[V, W], fn func(V, W)) {
 	}
 }
 
-// ForEach2 is a convenience method for chaining [ForEach2] on [Iterator2]s.
-func (iterator Iterator2[V, W]) ForEach2(fn func(V, W)) {
+// ForEach is a convenience method for chaining [ForEach] on [Iterator2]s.
+func (iterator Iterator2[V, W]) ForEach(fn func(V, W)) {
 	ForEach2(iter.Seq2[V, W](iterator), fn)
 }
 

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -6,51 +6,15 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
 	"github.com/BooleanCat/go-functional/v2/iter/op"
 )
 
-func ExampleCollect() {
-	fmt.Println(iter.Collect(iter.Lift([]int{1, 2, 3})))
-	// Output: [1 2 3]
-}
-
 func ExampleCollect_method() {
-	fmt.Println(iter.Lift([]int{1, 2, 3}).Collect())
+	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3})).Collect())
 	// Output: [1 2 3]
-}
-
-func TestCollectEmpty(t *testing.T) {
-	t.Parallel()
-
-	assert.Empty[int](t, iter.Collect(iter.Lift([]int{})))
-}
-
-func ExampleLift() {
-	for number := range iter.Lift([]int{1, 2, 3}) {
-		fmt.Println(number)
-	}
-
-	// Output:
-	// 1
-	// 2
-	// 3
-}
-
-func TestLiftEmpty(t *testing.T) {
-	t.Parallel()
-
-	for number := range iter.Lift([]int{}) {
-		t.Error("unexpected", number)
-	}
-}
-
-func TestLiftTerminateEarly(t *testing.T) {
-	t.Parallel()
-
-	_, stop := it.Pull(it.Seq[int](iter.Lift([]int{1, 2, 3})))
-	stop()
 }
 
 func ExampleLiftHashMap() {
@@ -100,7 +64,7 @@ func TestLiftHashMapTerminateEarly(t *testing.T) {
 }
 
 func ExampleForEach() {
-	iter.ForEach(iter.Lift([]int{1, 2, 3}), func(number int) {
+	iter.ForEach(iter.Iterator[int](slices.Values([]int{1, 2, 3})), func(number int) {
 		fmt.Println(number)
 	})
 	// Output:
@@ -110,7 +74,7 @@ func ExampleForEach() {
 }
 
 func ExampleForEach_method() {
-	iter.Lift([]int{1, 2, 3}).ForEach(func(number int) {
+	iter.Iterator[int](slices.Values([]int{1, 2, 3})).ForEach(func(number int) {
 		fmt.Println(number)
 	})
 	// Output:
@@ -122,13 +86,13 @@ func ExampleForEach_method() {
 func TestForEachEmpty(t *testing.T) {
 	t.Parallel()
 
-	iter.ForEach(iter.Lift([]int{}), func(int) {
+	iter.ForEach(iter.Iterator[int](slices.Values([]int{})), func(int) {
 		t.Error("unexpected")
 	})
 }
 
 func ExampleForEach2() {
-	iter.ForEach2(iter.Lift([]int{1, 2, 3}).Enumerate(), func(index int, number int) {
+	iter.ForEach2(iter.Iterator[int](slices.Values([]int{1, 2, 3})).Enumerate(), func(index int, number int) {
 		fmt.Println(index, number)
 	})
 	// Output:
@@ -138,7 +102,7 @@ func ExampleForEach2() {
 }
 
 func ExampleForEach2_method() {
-	iter.Lift([]int{1, 2, 3}).Enumerate().ForEach2(func(index int, number int) {
+	iter.Iterator[int](slices.Values([]int{1, 2, 3})).Enumerate().ForEach2(func(index int, number int) {
 		fmt.Println(index, number)
 	})
 	// Output:
@@ -150,24 +114,24 @@ func ExampleForEach2_method() {
 func TestForEach2Empty(t *testing.T) {
 	t.Parallel()
 
-	iter.ForEach2(iter.Lift([]int{}).Enumerate(), func(int, int) {
+	iter.ForEach2(iter.Iterator[int](slices.Values([]int{})).Enumerate(), func(int, int) {
 		t.Error("unexpected")
 	})
 }
 
 func ExampleReduce() {
-	fmt.Println(iter.Reduce(iter.Lift([]int{1, 2, 3}), op.Add, 0))
+	fmt.Println(iter.Reduce(iter.Iterator[int](slices.Values([]int{1, 2, 3})), op.Add, 0))
 	// Output: 6
 }
 
 func TestReduceEmpty(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, iter.Reduce(iter.Lift([]int{}), func(int, int) int { return 0 }, 0), 0)
+	assert.Equal(t, iter.Reduce(iter.Iterator[int](slices.Values([]int{})), func(int, int) int { return 0 }, 0), 0)
 }
 
 func ExampleReduce2() {
-	fmt.Println(iter.Reduce2(iter.Lift([]int{1, 2, 3}).Enumerate(), func(i, a, b int) int {
+	fmt.Println(iter.Reduce2(iter.Iterator[int](slices.Values([]int{1, 2, 3})).Enumerate(), func(i, a, b int) int {
 		return i + 1
 	}, 0))
 

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -54,7 +54,7 @@ func ExampleForEach2() {
 }
 
 func ExampleForEach2_method() {
-	iter.Iterator[int](slices.Values([]int{1, 2, 3})).Enumerate().ForEach2(func(index int, number int) {
+	iter.Iterator[int](slices.Values([]int{1, 2, 3})).Enumerate().ForEach(func(index int, number int) {
 		fmt.Println(index, number)
 	})
 	// Output:

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -64,7 +64,7 @@ func TestLiftHashMapTerminateEarly(t *testing.T) {
 }
 
 func ExampleForEach() {
-	iter.ForEach(iter.Iterator[int](slices.Values([]int{1, 2, 3})), func(number int) {
+	iter.ForEach(slices.Values([]int{1, 2, 3}), func(number int) {
 		fmt.Println(number)
 	})
 	// Output:
@@ -86,13 +86,13 @@ func ExampleForEach_method() {
 func TestForEachEmpty(t *testing.T) {
 	t.Parallel()
 
-	iter.ForEach(iter.Iterator[int](slices.Values([]int{})), func(int) {
+	iter.ForEach(slices.Values([]int{}), func(int) {
 		t.Error("unexpected")
 	})
 }
 
 func ExampleForEach2() {
-	iter.ForEach2(iter.Iterator[int](slices.Values([]int{1, 2, 3})).Enumerate(), func(index int, number int) {
+	iter.ForEach2(iter.Enumerate[int](slices.Values([]int{1, 2, 3})), func(index int, number int) {
 		fmt.Println(index, number)
 	})
 	// Output:
@@ -114,24 +114,24 @@ func ExampleForEach2_method() {
 func TestForEach2Empty(t *testing.T) {
 	t.Parallel()
 
-	iter.ForEach2(iter.Iterator[int](slices.Values([]int{})).Enumerate(), func(int, int) {
+	iter.ForEach2(iter.Enumerate[int](slices.Values([]int{})), func(int, int) {
 		t.Error("unexpected")
 	})
 }
 
 func ExampleReduce() {
-	fmt.Println(iter.Reduce(iter.Iterator[int](slices.Values([]int{1, 2, 3})), op.Add, 0))
+	fmt.Println(iter.Reduce(slices.Values([]int{1, 2, 3}), op.Add, 0))
 	// Output: 6
 }
 
 func TestReduceEmpty(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, iter.Reduce(iter.Iterator[int](slices.Values([]int{})), func(int, int) int { return 0 }, 0), 0)
+	assert.Equal(t, iter.Reduce(slices.Values([]int{}), func(int, int) int { return 0 }, 0), 0)
 }
 
 func ExampleReduce2() {
-	fmt.Println(iter.Reduce2(iter.Iterator[int](slices.Values([]int{1, 2, 3})).Enumerate(), func(i, a, b int) int {
+	fmt.Println(iter.Reduce2(iter.Enumerate[int](slices.Values([]int{1, 2, 3})), func(i, a, b int) int {
 		return i + 1
 	}, 0))
 

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -2,8 +2,6 @@ package iter_test
 
 import (
 	"fmt"
-	it "iter"
-	"sort"
 	"testing"
 
 	"github.com/BooleanCat/go-functional/v2/future/slices"
@@ -15,52 +13,6 @@ import (
 func ExampleCollect_method() {
 	fmt.Println(iter.Iterator[int](slices.Values([]int{1, 2, 3})).Collect())
 	// Output: [1 2 3]
-}
-
-func ExampleLiftHashMap() {
-	for key, value := range iter.LiftHashMap(map[int]string{1: "one", 2: "two", 3: "three"}) {
-		fmt.Println(key, value)
-	}
-}
-
-type keyValuePair[K comparable, V any] struct {
-	key   K
-	value V
-}
-
-func TestLiftHashMap(t *testing.T) {
-	t.Parallel()
-
-	values := make([]keyValuePair[int, string], 0, 3)
-
-	for key, value := range iter.LiftHashMap(map[int]string{1: "one", 2: "two", 3: "three"}) {
-		values = append(values, keyValuePair[int, string]{key, value})
-	}
-
-	sort.Slice(values, func(i, j int) bool {
-		return values[i].key < values[j].key
-	})
-
-	assert.SliceEqual(t, values, []keyValuePair[int, string]{
-		{1, "one"},
-		{2, "two"},
-		{3, "three"},
-	})
-}
-
-func TestLiftHashMapEmpty(t *testing.T) {
-	t.Parallel()
-
-	for _, _ = range iter.LiftHashMap(map[int]string{}) {
-		t.Error("unexpected")
-	}
-}
-
-func TestLiftHashMapTerminateEarly(t *testing.T) {
-	t.Parallel()
-
-	_, stop := it.Pull2(it.Seq2[int, string](iter.LiftHashMap(map[int]string{1: "one", 2: "two", 3: "three"})))
-	stop()
 }
 
 func ExampleForEach() {

--- a/iter/map.go
+++ b/iter/map.go
@@ -12,3 +12,15 @@ func Map[V, W any](delegate iter.Seq[V], transform func(V) W) iter.Seq[W] {
 		}
 	}
 }
+
+// Map2 yields pairs of values from an iterator that have been transformed by a
+// function.
+func Map2[V, W, X, Y any](delegate iter.Seq2[V, W], transform func(V, W) (X, Y)) iter.Seq2[X, Y] {
+	return func(yield func(X, Y) bool) {
+		for v, w := range delegate {
+			if !yield(transform(v, w)) {
+				return
+			}
+		}
+	}
+}

--- a/iter/map.go
+++ b/iter/map.go
@@ -3,12 +3,12 @@ package iter
 import "iter"
 
 // Map yields values from an iterator that have been transformed by a function.
-func Map[V, W any](delegate Iterator[V], transform func(V) W) Iterator[W] {
-	return Iterator[W](iter.Seq[W](func(yield func(W) bool) {
+func Map[V, W any](delegate iter.Seq[V], transform func(V) W) iter.Seq[W] {
+	return func(yield func(W) bool) {
 		for value := range delegate {
 			if !yield(transform(value)) {
 				return
 			}
 		}
-	}))
+	}
 }

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/BooleanCat/go-functional/v2/future/slices"
+	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
 )
 
@@ -25,9 +26,7 @@ func ExampleMap() {
 func TestMapEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Map(slices.Values([]int{}), func(int) int { return 0 }) {
-		t.Error("unexpected")
-	}
+	assert.Empty[int](t, slices.Collect(iter.Map(slices.Values([]int{}), func(int) int { return 0 })))
 }
 
 func TestMapTerminateEarly(t *testing.T) {

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -12,7 +12,7 @@ import (
 func ExampleMap() {
 	double := func(n int) int { return n * 2 }
 
-	for number := range iter.Map(iter.Iterator[int](slices.Values([]int{1, 2, 3})), double) {
+	for number := range iter.Map(slices.Values([]int{1, 2, 3}), double) {
 		fmt.Println(number)
 	}
 
@@ -25,7 +25,7 @@ func ExampleMap() {
 func TestMapEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Map(iter.Iterator[int](slices.Values([]int{})), func(int) int { return 0 }) {
+	for _ = range iter.Map(slices.Values([]int{}), func(int) int { return 0 }) {
 		t.Error("unexpected")
 	}
 }
@@ -33,6 +33,6 @@ func TestMapEmpty(t *testing.T) {
 func TestMapTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(it.Seq[int](iter.Map(iter.Iterator[int](slices.Values([]int{1, 2, 3})), func(int) int { return 0 })))
+	_, stop := it.Pull(iter.Map(slices.Values([]int{1, 2, 3}), func(int) int { return 0 }))
 	stop()
 }

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -5,6 +5,7 @@ import (
 	it "iter"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/maps"
 	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
@@ -33,5 +34,35 @@ func TestMapTerminateEarly(t *testing.T) {
 	t.Parallel()
 
 	_, stop := it.Pull(iter.Map(slices.Values([]int{1, 2, 3}), func(int) int { return 0 }))
+	stop()
+}
+
+func ExampleMap2() {
+	doubleBoth := func(n, m int) (int, int) { return n * 2, m * 2 }
+
+	for left, right := range iter.Map2(iter.Zip(slices.Values([]int{1, 2, 3}), slices.Values([]int{2, 3, 4})), doubleBoth) {
+		fmt.Println(left, right)
+	}
+
+	// Output:
+	// 2 4
+	// 4 6
+	// 6 8
+}
+
+func TestMap2Empty(t *testing.T) {
+	t.Parallel()
+
+	doubleBoth := func(n, m int) (int, int) { return n * 2, m * 2 }
+
+	assert.Equal(t, len(maps.Collect(iter.Map2(maps.All(map[int]int{}), doubleBoth))), 0)
+}
+
+func TestMap2TerminateEarly(t *testing.T) {
+	t.Parallel()
+
+	doubleBoth := func(n, m int) (int, int) { return n * 2, m * 2 }
+
+	_, stop := it.Pull2(iter.Map2(maps.All(map[int]int{1: 2}), doubleBoth))
 	stop()
 }

--- a/iter/map_test.go
+++ b/iter/map_test.go
@@ -5,13 +5,14 @@ import (
 	it "iter"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/iter"
 )
 
 func ExampleMap() {
 	double := func(n int) int { return n * 2 }
 
-	for number := range iter.Map(iter.Lift([]int{1, 2, 3}), double) {
+	for number := range iter.Map(iter.Iterator[int](slices.Values([]int{1, 2, 3})), double) {
 		fmt.Println(number)
 	}
 
@@ -24,7 +25,7 @@ func ExampleMap() {
 func TestMapEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Map(iter.Lift([]int{}), func(int) int { return 0 }) {
+	for _ = range iter.Map(iter.Iterator[int](slices.Values([]int{})), func(int) int { return 0 }) {
 		t.Error("unexpected")
 	}
 }
@@ -32,6 +33,6 @@ func TestMapEmpty(t *testing.T) {
 func TestMapTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(it.Seq[int](iter.Map(iter.Lift([]int{1, 2, 3}), func(int) int { return 0 })))
+	_, stop := it.Pull(it.Seq[int](iter.Map(iter.Iterator[int](slices.Values([]int{1, 2, 3})), func(int) int { return 0 })))
 	stop()
 }

--- a/iter/op/op_test.go
+++ b/iter/op/op_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func ExampleAdd() {
-	fmt.Println(iter.Reduce(iter.Iterator[int](slices.Values([]int{1, 2, 3})), op.Add, 0))
+	fmt.Println(iter.Reduce(slices.Values([]int{1, 2, 3}), op.Add, 0))
 	// Output: 6
 }
 
 func ExampleAdd_string() {
-	fmt.Println(iter.Reduce(iter.Iterator[string](slices.Values([]string{"a", "b", "c"})), op.Add, ""))
+	fmt.Println(iter.Reduce(slices.Values([]string{"a", "b", "c"}), op.Add, ""))
 	// Output: abc
 }

--- a/iter/op/op_test.go
+++ b/iter/op/op_test.go
@@ -3,16 +3,17 @@ package op_test
 import (
 	"fmt"
 
+	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/iter"
 	"github.com/BooleanCat/go-functional/v2/iter/op"
 )
 
 func ExampleAdd() {
-	fmt.Println(iter.Reduce(iter.Lift([]int{1, 2, 3}), op.Add, 0))
+	fmt.Println(iter.Reduce(iter.Iterator[int](slices.Values([]int{1, 2, 3})), op.Add, 0))
 	// Output: 6
 }
 
 func ExampleAdd_string() {
-	fmt.Println(iter.Reduce(iter.Lift([]string{"a", "b", "c"}), op.Add, ""))
+	fmt.Println(iter.Reduce(iter.Iterator[string](slices.Values([]string{"a", "b", "c"})), op.Add, ""))
 	// Output: abc
 }

--- a/iter/take.go
+++ b/iter/take.go
@@ -24,5 +24,5 @@ func Take[V any](delegate iter.Seq[V], limit int) iter.Seq[V] {
 
 // Take is a convenience method for chaining [Take] on [Iterator]s.
 func (iterator Iterator[V]) Take(limit int) Iterator[V] {
-	return Iterator[V](Take[V](iter.Seq[V](iterator), limit))
+	return Iterator[V](Take(iter.Seq[V](iterator), limit))
 }

--- a/iter/take.go
+++ b/iter/take.go
@@ -3,8 +3,8 @@ package iter
 import "iter"
 
 // Take yields the first `limit` values from a delegate [Iterator].
-func Take[V any](delegate Iterator[V], limit int) Iterator[V] {
-	return Iterator[V](iter.Seq[V](func(yield func(V) bool) {
+func Take[V any](delegate iter.Seq[V], limit int) iter.Seq[V] {
+	return func(yield func(V) bool) {
 		if limit <= 0 {
 			return
 		}
@@ -19,10 +19,10 @@ func Take[V any](delegate Iterator[V], limit int) Iterator[V] {
 				return
 			}
 		}
-	}))
+	}
 }
 
 // Take is a convenience method for chaining [Take] on [Iterator]s.
-func (iter Iterator[V]) Take(limit int) Iterator[V] {
-	return Take[V](iter, limit)
+func (iterator Iterator[V]) Take(limit int) Iterator[V] {
+	return Iterator[V](Take[V](iter.Seq[V](iterator), limit))
 }

--- a/iter/take.go
+++ b/iter/take.go
@@ -26,3 +26,28 @@ func Take[V any](delegate iter.Seq[V], limit int) iter.Seq[V] {
 func (iterator Iterator[V]) Take(limit int) Iterator[V] {
 	return Iterator[V](Take(iter.Seq[V](iterator), limit))
 }
+
+// Take2 yields the first `limit` pairs of values from a delegate [Iterator2].
+func Take2[V, W any](delegate iter.Seq2[V, W], limit int) iter.Seq2[V, W] {
+	return func(yield func(V, W) bool) {
+		if limit <= 0 {
+			return
+		}
+
+		for v, w := range delegate {
+			if !yield(v, w) {
+				return
+			}
+
+			limit--
+			if limit <= 0 {
+				return
+			}
+		}
+	}
+}
+
+// Take is a convenience method for chaining [Take] on [Iterator2]s.
+func (iterator Iterator2[V, W]) Take(limit int) Iterator2[V, W] {
+	return Iterator2[V, W](Take2(iter.Seq2[V, W](iterator), limit))
+}

--- a/iter/take_test.go
+++ b/iter/take_test.go
@@ -3,8 +3,10 @@ package iter_test
 import (
 	"fmt"
 	it "iter"
+	sl "slices"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/maps"
 	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
@@ -49,4 +51,54 @@ func TestTakeEmpty(t *testing.T) {
 	t.Parallel()
 
 	assert.Empty[int](t, slices.Collect(iter.Take(slices.Values([]int{}), 2)))
+}
+
+func ExampleTake2() {
+	numbers := maps.Collect(iter.Take2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"}), 2))
+
+	fmt.Println(len(numbers))
+	// Output: 2
+}
+
+func ExampleTake2_method() {
+	numbers := maps.Collect(it.Seq2[int, string](iter.Iterator2[int, string](maps.All(map[int]string{1: "one", 2: "two", 3: "three"})).Take(2)))
+
+	fmt.Println(len(numbers))
+	// Output: 2
+}
+
+func TestTake2(t *testing.T) {
+	t.Parallel()
+
+	keys := []int{1, 2, 3}
+	values := []string{"one", "two", "three"}
+
+	numbers := maps.Collect(iter.Take2(iter.Zip(slices.Values(keys), slices.Values(values)), 2))
+
+	assert.Equal(t, len(numbers), 2)
+
+	for key := range numbers {
+		assert.True(t, sl.Contains(keys, key))
+	}
+}
+
+func TestTake2Zero(t *testing.T) {
+	t.Parallel()
+
+	numbers := maps.Collect(iter.Take2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"}), 0))
+	assert.Equal(t, len(numbers), 0)
+}
+
+func TestTake2Empty(t *testing.T) {
+	t.Parallel()
+
+	numbers := maps.Collect(iter.Take2(maps.All(map[int]string{}), 2))
+	assert.Equal(t, len(numbers), 0)
+}
+
+func TestTake2TerminateEarly(t *testing.T) {
+	t.Parallel()
+
+	_, stop := it.Pull2(iter.Take2(maps.All(map[int]string{1: "one", 2: "two"}), 1))
+	stop()
 }

--- a/iter/take_test.go
+++ b/iter/take_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleTake() {
-	for number := range iter.Take(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})), 3) {
+	for number := range iter.Take(slices.Values([]int{1, 2, 3, 4, 5}), 3) {
 		fmt.Println(number)
 	}
 
@@ -34,14 +34,14 @@ func ExampleTake_method() {
 func TestTakeTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(it.Seq[int](iter.Take(iter.Iterator[int](slices.Values([]int{1, 2, 3})), 2)))
+	_, stop := it.Pull(iter.Take(slices.Values([]int{1, 2, 3}), 2))
 	stop()
 }
 
 func TestTakeZero(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Take(iter.Iterator[int](slices.Values([]int{1, 2, 3})), 0) {
+	for _ = range iter.Take(slices.Values([]int{1, 2, 3}), 0) {
 		t.Error("unexpected")
 	}
 }

--- a/iter/take_test.go
+++ b/iter/take_test.go
@@ -5,11 +5,12 @@ import (
 	it "iter"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/iter"
 )
 
 func ExampleTake() {
-	for number := range iter.Take(iter.Lift([]int{1, 2, 3, 4, 5}), 3) {
+	for number := range iter.Take(iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})), 3) {
 		fmt.Println(number)
 	}
 
@@ -20,7 +21,7 @@ func ExampleTake() {
 }
 
 func ExampleTake_method() {
-	for number := range iter.Lift([]int{1, 2, 3, 4, 5}).Take(3) {
+	for number := range iter.Iterator[int](slices.Values([]int{1, 2, 3, 4, 5})).Take(3) {
 		fmt.Println(number)
 	}
 
@@ -33,14 +34,14 @@ func ExampleTake_method() {
 func TestTakeTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull(it.Seq[int](iter.Take(iter.Lift([]int{1, 2, 3}), 2)))
+	_, stop := it.Pull(it.Seq[int](iter.Take(iter.Iterator[int](slices.Values([]int{1, 2, 3})), 2)))
 	stop()
 }
 
 func TestTakeZero(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Take(iter.Lift([]int{1, 2, 3}), 0) {
+	for _ = range iter.Take(iter.Iterator[int](slices.Values([]int{1, 2, 3})), 0) {
 		t.Error("unexpected")
 	}
 }

--- a/iter/take_test.go
+++ b/iter/take_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/BooleanCat/go-functional/v2/future/slices"
+	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
 )
 
@@ -41,7 +42,11 @@ func TestTakeTerminateEarly(t *testing.T) {
 func TestTakeZero(t *testing.T) {
 	t.Parallel()
 
-	for _ = range iter.Take(slices.Values([]int{1, 2, 3}), 0) {
-		t.Error("unexpected")
-	}
+	assert.Empty[int](t, slices.Collect(iter.Take(slices.Values([]int{1, 2, 3}), 0)))
+}
+
+func TestTakeEmpty(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty[int](t, slices.Collect(iter.Take(slices.Values([]int{}), 2)))
 }

--- a/iter/zip.go
+++ b/iter/zip.go
@@ -9,7 +9,7 @@ import (
 
 // Zip yields pairs of values from two iterators.
 func Zip[V, W any](left iter.Seq[V], right iter.Seq[W]) iter.Seq2[V, W] {
-	return iter.Seq2[V, W](func(yield func(V, W) bool) {
+	return func(yield func(V, W) bool) {
 		left, stop := iter.Pull(left)
 		defer stop()
 
@@ -28,7 +28,7 @@ func Zip[V, W any](left iter.Seq[V], right iter.Seq[W]) iter.Seq2[V, W] {
 				return
 			}
 		}
-	})
+	}
 }
 
 // Unzip returns two [Iterator]s from a single [Iterator2].
@@ -56,7 +56,7 @@ func Unzip[V, W any](delegate iter.Seq2[V, W]) (iter.Seq[V], iter.Seq[W]) {
 		stop()
 	}()
 
-	return iter.Seq[V](func(yield func(V) bool) {
+	return func(yield func(V) bool) {
 			defer done.Done()
 
 			for {
@@ -81,7 +81,7 @@ func Unzip[V, W any](delegate iter.Seq2[V, W]) (iter.Seq[V], iter.Seq[W]) {
 					return
 				}
 			}
-		}), iter.Seq[W](func(yield func(W) bool) {
+		}, func(yield func(W) bool) {
 			defer done.Done()
 
 			for {
@@ -106,7 +106,7 @@ func Unzip[V, W any](delegate iter.Seq2[V, W]) (iter.Seq[V], iter.Seq[W]) {
 					return
 				}
 			}
-		})
+		}
 }
 
 // Unzip is a convenience method for chaining [Unzip] on [Iterator2]s.

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/maps"
 	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
@@ -39,7 +40,7 @@ func TestZipTerminateEarly(t *testing.T) {
 }
 
 func ExampleUnzip() {
-	keys, values := iter.Unzip(it.Seq2[int, string](iter.LiftHashMap(map[int]string{1: "one", 2: "two"})))
+	keys, values := iter.Unzip(maps.All(map[int]string{1: "one", 2: "two"}))
 
 	for key := range keys {
 		fmt.Println(key)
@@ -51,7 +52,7 @@ func ExampleUnzip() {
 }
 
 func ExampleUnzip_method() {
-	keys, values := iter.LiftHashMap(map[int]string{1: "one", 2: "two"}).Unzip()
+	keys, values := iter.Iterator2[int, string](maps.All(map[int]string{1: "one", 2: "two"})).Unzip()
 
 	for key := range keys {
 		fmt.Println(key)
@@ -129,7 +130,7 @@ func TestUnzipTerminateEarly(t *testing.T) {
 func TestUnzipTerminateLeftEarly(t *testing.T) {
 	t.Parallel()
 
-	numbers, strings := iter.Unzip(it.Seq2[int, string](iter.LiftHashMap(map[int]string{1: "one", 2: "two"})))
+	numbers, strings := iter.Unzip(maps.All(map[int]string{1: "one", 2: "two"}))
 
 	_, stop := it.Pull(numbers)
 	stop()
@@ -140,7 +141,7 @@ func TestUnzipTerminateLeftEarly(t *testing.T) {
 func TestUnzipTerminateRightEarly(t *testing.T) {
 	t.Parallel()
 
-	numbers, strings := iter.Unzip(it.Seq2[int, string](iter.LiftHashMap(map[int]string{1: "one", 2: "two"})))
+	numbers, strings := iter.Unzip(maps.All(map[int]string{1: "one", 2: "two"}))
 
 	_, stop := it.Pull(strings)
 	stop()
@@ -149,7 +150,7 @@ func TestUnzipTerminateRightEarly(t *testing.T) {
 }
 
 func TestUnzipMethod(t *testing.T) {
-	keys, values := iter.LiftHashMap(map[int]string{1: "one"}).Unzip()
+	keys, values := iter.Iterator2[int, string](maps.All(map[int]string{1: "one"})).Unzip()
 
 	assert.SliceEqual(t, keys.Collect(), []int{1})
 	assert.SliceEqual(t, values.Collect(), []string{"one"})

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -7,12 +7,13 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/future/slices"
 	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	"github.com/BooleanCat/go-functional/v2/iter"
 )
 
 func ExampleZip() {
-	for left, right := range iter.Zip(iter.Lift([]int{1, 2, 3}), iter.Lift([]string{"one", "two", "three"})) {
+	for left, right := range iter.Zip(iter.Iterator[int](slices.Values([]int{1, 2, 3})), iter.Iterator[string](slices.Values([]string{"one", "two", "three"}))) {
 		fmt.Println(left, right)
 	}
 
@@ -25,7 +26,7 @@ func ExampleZip() {
 func TestZipEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range iter.Zip(iter.Lift([]int{}), iter.Lift([]string{})) {
+	for _, _ = range iter.Zip(iter.Iterator[int](slices.Values([]int{})), iter.Iterator[string](slices.Values([]string{}))) {
 		t.Error("unexpected")
 	}
 }
@@ -33,7 +34,7 @@ func TestZipEmpty(t *testing.T) {
 func TestZipTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(it.Seq2[int, string](iter.Zip(iter.Lift([]int{1, 2}), iter.Lift([]string{"one", "two"}))))
+	_, stop := it.Pull2(it.Seq2[int, string](iter.Zip(iter.Iterator[int](slices.Values([]int{1, 2})), iter.Iterator[string](slices.Values([]string{"one", "two"})))))
 	stop()
 }
 
@@ -62,7 +63,7 @@ func ExampleUnzip_method() {
 }
 
 func TestUnzip(t *testing.T) {
-	zipped := iter.Zip(iter.Lift([]int{1, 2, 3}), iter.Lift([]string{"one", "two", "three"}))
+	zipped := iter.Zip(iter.Iterator[int](slices.Values([]int{1, 2, 3})), iter.Iterator[string](slices.Values([]string{"one", "two", "three"})))
 
 	numbers, strings := iter.Unzip(zipped)
 
@@ -81,7 +82,7 @@ func TestUnzipRace(t *testing.T) {
 		strings = append(strings, strconv.Itoa(i))
 	}
 
-	zipped := iter.Zip(iter.Lift(numbers), iter.Lift(strings))
+	zipped := iter.Zip(iter.Iterator[int](slices.Values(numbers)), iter.Iterator[string](slices.Values(strings)))
 
 	numbersIter, stringsIter := iter.Unzip(zipped)
 
@@ -114,7 +115,7 @@ func TestUnzipRace(t *testing.T) {
 func TestUnzipTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	zipped := iter.Zip(iter.Lift([]int{1, 2}), iter.Lift([]string{"one", "two"}))
+	zipped := iter.Zip(iter.Iterator[int](slices.Values([]int{1, 2})), iter.Iterator[string](slices.Values([]string{"one", "two"})))
 
 	numbers, strings := iter.Unzip(zipped)
 

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func ExampleZip() {
-	for left, right := range iter.Zip(iter.Iterator[int](slices.Values([]int{1, 2, 3})), iter.Iterator[string](slices.Values([]string{"one", "two", "three"}))) {
+	for left, right := range iter.Zip(slices.Values([]int{1, 2, 3}), slices.Values([]string{"one", "two", "three"})) {
 		fmt.Println(left, right)
 	}
 
@@ -26,7 +26,7 @@ func ExampleZip() {
 func TestZipEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range iter.Zip(iter.Iterator[int](slices.Values([]int{})), iter.Iterator[string](slices.Values([]string{}))) {
+	for _, _ = range iter.Zip(slices.Values([]int{}), slices.Values([]string{})) {
 		t.Error("unexpected")
 	}
 }
@@ -34,12 +34,12 @@ func TestZipEmpty(t *testing.T) {
 func TestZipTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	_, stop := it.Pull2(it.Seq2[int, string](iter.Zip(iter.Iterator[int](slices.Values([]int{1, 2})), iter.Iterator[string](slices.Values([]string{"one", "two"})))))
+	_, stop := it.Pull2(iter.Zip(slices.Values([]int{1, 2}), slices.Values([]string{"one", "two"})))
 	stop()
 }
 
 func ExampleUnzip() {
-	keys, values := iter.Unzip(iter.LiftHashMap(map[int]string{1: "one", 2: "two"}))
+	keys, values := iter.Unzip(it.Seq2[int, string](iter.LiftHashMap(map[int]string{1: "one", 2: "two"})))
 
 	for key := range keys {
 		fmt.Println(key)
@@ -63,12 +63,12 @@ func ExampleUnzip_method() {
 }
 
 func TestUnzip(t *testing.T) {
-	zipped := iter.Zip(iter.Iterator[int](slices.Values([]int{1, 2, 3})), iter.Iterator[string](slices.Values([]string{"one", "two", "three"})))
+	zipped := iter.Zip(slices.Values([]int{1, 2, 3}), slices.Values([]string{"one", "two", "three"}))
 
 	numbers, strings := iter.Unzip(zipped)
 
-	assert.SliceEqual(t, numbers.Collect(), []int{1, 2, 3})
-	assert.SliceEqual(t, strings.Collect(), []string{"one", "two", "three"})
+	assert.SliceEqual(t, slices.Collect(numbers), []int{1, 2, 3})
+	assert.SliceEqual(t, slices.Collect(strings), []string{"one", "two", "three"})
 }
 
 func TestUnzipRace(t *testing.T) {
@@ -82,7 +82,7 @@ func TestUnzipRace(t *testing.T) {
 		strings = append(strings, strconv.Itoa(i))
 	}
 
-	zipped := iter.Zip(iter.Iterator[int](slices.Values(numbers)), iter.Iterator[string](slices.Values(strings)))
+	zipped := iter.Zip(slices.Values(numbers), slices.Values(strings))
 
 	numbersIter, stringsIter := iter.Unzip(zipped)
 
@@ -115,37 +115,37 @@ func TestUnzipRace(t *testing.T) {
 func TestUnzipTerminateEarly(t *testing.T) {
 	t.Parallel()
 
-	zipped := iter.Zip(iter.Iterator[int](slices.Values([]int{1, 2})), iter.Iterator[string](slices.Values([]string{"one", "two"})))
+	zipped := iter.Zip(slices.Values([]int{1, 2}), slices.Values([]string{"one", "two"}))
 
 	numbers, strings := iter.Unzip(zipped)
 
-	_, stop := it.Pull(it.Seq[int](numbers))
+	_, stop := it.Pull(numbers)
 	stop()
 
-	_, stop = it.Pull(it.Seq[string](strings))
+	_, stop = it.Pull(strings)
 	stop()
 }
 
 func TestUnzipTerminateLeftEarly(t *testing.T) {
 	t.Parallel()
 
-	numbers, strings := iter.Unzip(iter.LiftHashMap(map[int]string{1: "one", 2: "two"}))
+	numbers, strings := iter.Unzip(it.Seq2[int, string](iter.LiftHashMap(map[int]string{1: "one", 2: "two"})))
 
-	_, stop := it.Pull(it.Seq[int](numbers))
+	_, stop := it.Pull(numbers)
 	stop()
 
-	assert.EqualElements(t, strings.Collect(), []string{"one", "two"})
+	assert.EqualElements(t, slices.Collect(strings), []string{"one", "two"})
 }
 
 func TestUnzipTerminateRightEarly(t *testing.T) {
 	t.Parallel()
 
-	numbers, strings := iter.Unzip(iter.LiftHashMap(map[int]string{1: "one", 2: "two"}))
+	numbers, strings := iter.Unzip(it.Seq2[int, string](iter.LiftHashMap(map[int]string{1: "one", 2: "two"})))
 
-	_, stop := it.Pull(it.Seq[string](strings))
+	_, stop := it.Pull(strings)
 	stop()
 
-	assert.EqualElements(t, numbers.Collect(), []int{1, 2})
+	assert.EqualElements(t, slices.Collect(numbers), []int{1, 2})
 }
 
 func TestUnzipMethod(t *testing.T) {

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -27,9 +27,7 @@ func ExampleZip() {
 func TestZipEmpty(t *testing.T) {
 	t.Parallel()
 
-	for _, _ = range iter.Zip(slices.Values([]int{}), slices.Values([]string{})) {
-		t.Error("unexpected")
-	}
+	assert.Equal(t, len(maps.Collect(iter.Zip(slices.Values([]int{}), slices.Values([]string{})))), 0)
 }
 
 func TestZipTerminateEarly(t *testing.T) {


### PR DESCRIPTION
**Please provide a brief description of the change.**

- All iterators now natively return and use the `Seq` types rather than this projects type alias, favouring compatibility with the standard library over convenience features like chaining.
- Added iterators for the Seq2 variants of existing iterators
- Renamed `Lift` to `Values` and moved to future shadow package `slices` (to be deleted when Go 1.23 is released)
- Renamed `LiftHashMap` to `All` and moved to future shadow package `maps` (to be deleted when Go 1.23 is released)

**Which issue does this change relate to?**

None.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies

**Additional context**

There are breaking changes here.
