### PR TITLE
Improve test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ test:
 
 cov: SHELL:=/bin/bash
 cov:
-	$(GO_BINARY) test -race -coverprofile=coverage.txt -covermode=atomic $$( go list ./... | grep -v assert )
+	$(GO_BINARY) test -race -coverprofile=coverage.txt -covermode=atomic $$( $(GO_BINARY) list ./... | grep -v assert )

--- a/iter/take_test.go
+++ b/iter/take_test.go
@@ -33,17 +33,32 @@ func ExampleTake_method() {
 	// 3
 }
 
-func TestTakeTerminateEarly(t *testing.T) {
-	t.Parallel()
-
-	_, stop := iter.Pull(fn.Take(slices.Values([]int{1, 2, 3}), 2))
-	stop()
-}
-
 func TestTakeZero(t *testing.T) {
 	t.Parallel()
 
 	assert.Empty[int](t, slices.Collect(fn.Take(slices.Values([]int{1, 2, 3}), 0)))
+}
+
+func TestTakeMoreThanAvailable(t *testing.T) {
+	t.Parallel()
+
+	numbers := slices.Collect(fn.Take(slices.Values([]int{1, 2, 3}), 5))
+	assert.SliceEqual(t, []int{1, 2, 3}, numbers)
+}
+
+func TestTakeYieldFalse(t *testing.T) {
+	t.Parallel()
+
+	seq := fn.Take(slices.Values([]int{1, 2, 3, 4, 5}), 3)
+
+	values := []int{}
+	seq(func(v int) bool {
+		values = append(values, v)
+		return false
+	})
+
+	expected := []int{1}
+	assert.SliceEqual(t, expected, values)
 }
 
 func TestTakeEmpty(t *testing.T) {
@@ -95,9 +110,23 @@ func TestTake2Empty(t *testing.T) {
 	assert.Equal(t, len(numbers), 0)
 }
 
-func TestTake2TerminateEarly(t *testing.T) {
+func TestTake2MoreThanAvailable(t *testing.T) {
 	t.Parallel()
 
-	_, stop := iter.Pull2(fn.Take2(maps.All(map[int]string{1: "one", 2: "two"}), 1))
-	stop()
+	numbers := maps.Collect(fn.Take2(maps.All(map[int]string{1: "one", 2: "two"}), 3))
+	assert.Equal(t, len(numbers), 2)
+}
+
+func TestTake2YieldFalse(t *testing.T) {
+	t.Parallel()
+
+	seq := fn.Take2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"}), 2)
+
+	values := make(map[int]string)
+	seq(func(k int, v string) bool {
+		values[k] = v
+		return false
+	})
+
+	assert.Equal(t, len(values), 1)
 }


### PR DESCRIPTION
**Please provide a brief description of the change.**

Using the builtin slices and maps packages instead of the recently deleted future package has lowered coverage, this improves it.

**Which issue does this change relate to?**

N/A

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] My code is formatted (`make check`)
- [x] I have run tests (`make test`)
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies

