### PR TITLE
increase test coverage for channel, cycle, drop & zip

### DIFF
--- a/iter/channel_test.go
+++ b/iter/channel_test.go
@@ -2,7 +2,6 @@ package iter_test
 
 import (
 	"fmt"
-	"iter"
 	"slices"
 	"testing"
 
@@ -28,17 +27,21 @@ func ExampleFromChannel() {
 	// 2
 }
 
-func TestFromChannelTerminateEarly(t *testing.T) {
+func TestFromChannelYieldFalse(t *testing.T) {
 	t.Parallel()
 
-	channel := make(chan int, 1)
-	defer close(channel)
+	numbersChan := make(chan int, 1)
+	defer close(numbersChan)
 
-	channel <- 1
-	numbers := fn.FromChannel(channel)
+	numbersChan <- 1
+	numbers := fn.FromChannel(numbersChan)
 
-	_, stop := iter.Pull(numbers)
-	stop()
+	var a int
+	numbers(func(value int) bool {
+		a = value
+		return false
+	})
+	assert.Equal(t, a, 1)
 }
 
 func TestFromChannelEmpty(t *testing.T) {

--- a/iter/cycle_test.go
+++ b/iter/cycle_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/BooleanCat/go-functional/v2/internal/assert"
 	fn "github.com/BooleanCat/go-functional/v2/iter"
 )
 
@@ -24,11 +25,16 @@ func ExampleCycle_method() {
 	// Output: [1 2 1 2 1]
 }
 
-func TestCycleTerminateEarly(t *testing.T) {
+func TestCycleYieldFalse(t *testing.T) {
 	t.Parallel()
 
-	_, stop := iter.Pull(fn.Cycle(slices.Values([]int{1, 2})))
-	stop()
+	numbers := fn.Cycle(slices.Values([]int{1, 2}))
+	var a int
+	numbers(func(value int) bool {
+		a = value
+		return false
+	})
+	assert.Equal(t, a, 1)
 }
 
 func ExampleCycle2() {
@@ -45,9 +51,18 @@ func ExampleCycle2_method() {
 	// Output: map[1:one]
 }
 
-func TestCycle2TerminateEarly(t *testing.T) {
+func TestCycle2YieldFalse(t *testing.T) {
 	t.Parallel()
 
-	_, stop := iter.Pull2(fn.Cycle2(maps.All(map[int]string{1: "one"})))
-	stop()
+	numbers := fn.Cycle2(maps.All(map[int]string{1: "one"}))
+	var (
+		a int
+		b string
+	)
+	numbers(func(key int, value string) bool {
+		a, b = key, value
+		return false
+	})
+	assert.Equal(t, a, 1)
+	assert.Equal(t, b, "one")
 }

--- a/iter/drop_test.go
+++ b/iter/drop_test.go
@@ -33,11 +33,16 @@ func ExampleDrop_method() {
 	// 5
 }
 
-func TestDropTerminateEarly(t *testing.T) {
+func TestDropYieldFalse(t *testing.T) {
 	t.Parallel()
 
-	_, stop := iter.Pull(fn.Drop(slices.Values([]int{1, 2, 3}), 2))
-	stop()
+	numbers := fn.Drop(slices.Values([]int{1, 2, 3, 4, 5}), 2)
+	var a int
+	numbers(func(value int) bool {
+		a = value
+		return false
+	})
+	assert.Equal(t, a, 3)
 }
 
 func TestDropEmpty(t *testing.T) {
@@ -89,9 +94,16 @@ func TestDrop2Zero(t *testing.T) {
 	assert.Equal(t, len(numbers), 3)
 }
 
-func TestDrop2TerminateEarly(t *testing.T) {
+func TestDrop2YieldFalse(t *testing.T) {
 	t.Parallel()
 
-	_, stop := iter.Pull2(fn.Drop2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"}), 1))
-	stop()
+	numbersZipped := fn.Zip(slices.Values([]int{1, 2, 3}), slices.Values([]int{3, 4, 5}))
+	numbers := fn.Drop2(numbersZipped, 2)
+	var a, b int
+	numbers(func(v, w int) bool {
+		a, b = v, w
+		return false
+	})
+	assert.Equal(t, a, 3)
+	assert.Equal(t, b, 5)
 }

--- a/iter/zip_test.go
+++ b/iter/zip_test.go
@@ -111,18 +111,15 @@ func TestUnzipRace(t *testing.T) {
 	group.Wait()
 }
 
-func TestUnzipTerminateEarly(t *testing.T) {
+func TestUnzipYieldFalse(t *testing.T) {
 	t.Parallel()
 
 	zipped := fn.Zip(slices.Values([]int{1, 2}), slices.Values([]string{"one", "two"}))
 
 	numbers, strings := fn.Unzip(zipped)
 
-	_, stop := iter.Pull(numbers)
-	stop()
-
-	_, stop = iter.Pull(strings)
-	stop()
+	numbers(func(int) bool { return false })
+	strings(func(string) bool { return false })
 }
 
 func TestUnzipTerminateLeftEarly(t *testing.T) {


### PR DESCRIPTION
**Please provide a brief description of the change.**

Due to a change in how pull iterators are implemented, coverage dropped on these tests.

**Which issue does this change relate to?**

Closes #115 

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] My code is formatted (`make check`)
- [X] I have run tests (`make test`)
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies

**Additional context**

N/A
