### PR TITLE
Add CollectErr consumer and related helpers

### DIFF
--- a/it/iter.go
+++ b/it/iter.go
@@ -2,6 +2,7 @@ package it
 
 import (
 	"cmp"
+	"errors"
 	"iter"
 )
 
@@ -124,4 +125,20 @@ func Find2[V, W any](iterator func(func(V, W) bool), pred func(V, W) bool) (V, W
 	var zeroV V
 	var zeroW W
 	return zeroV, zeroW, false
+}
+
+// CollectErr consumes an [iter.Seq2] where the right side yields errors and
+// returns a slice of values and all errors joined together.
+func CollectErr[V any](delegate func(func(V, error) bool)) ([]V, error) {
+	var (
+		values []V
+		errs   []error
+	)
+
+	for v, err := range delegate {
+		values = append(values, v)
+		errs = append(errs, err)
+	}
+
+	return values, errors.Join(errs...)
 }

--- a/it/iter_test.go
+++ b/it/iter_test.go
@@ -3,6 +3,7 @@ package it_test
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/BooleanCat/go-functional/v2/internal/assert"
@@ -126,7 +127,17 @@ func ExampleFind2_notFound() {
 	index, value, ok := it.Find2(it.Enumerate(slices.Values([]int{1, 2, 3})), func(i, v int) bool {
 		return i == 4
 	})
-	fmt.Println(index, value, ok)
 
+	fmt.Println(index, value, ok)
 	// Output: 0 0 false
+}
+
+func ExampleCollectErr() {
+	data := strings.NewReader("one\ntwo\nthree\n")
+	lines, err := it.CollectErr(it.LinesString(data))
+	fmt.Println(err)
+	fmt.Println(lines)
+	// Output:
+	// <nil>
+	// [one two three]
 }

--- a/it/itx/iter.go
+++ b/it/itx/iter.go
@@ -73,3 +73,9 @@ func (iterator Iterator[V]) Find(predicate func(V) bool) (V, bool) {
 func (iterator Iterator2[V, W]) Find(predicate func(V, W) bool) (V, W, bool) {
 	return it.Find2(iterator, predicate)
 }
+
+// CollectErr consumes an [Iterator2] where the right side yields errors and
+// returns a slice of values and all errors yielded joined together.
+func CollectErr[V any](iterator Iterator2[V, error]) ([]V, error) {
+	return it.CollectErr(iter.Seq2[V, error](iterator))
+}

--- a/it/itx/iter_test.go
+++ b/it/itx/iter_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
@@ -76,4 +77,14 @@ func ExampleFromSlice() {
 func ExampleFromMap() {
 	fmt.Println(itx.FromMap(map[int]int{1: 2}).Right().Collect())
 	// Output: [2]
+}
+
+func ExampleCollectErr() {
+	data := strings.NewReader("one\ntwo\nthree\n")
+	lines, err := itx.CollectErr(itx.LinesString(data))
+	fmt.Println(err)
+	fmt.Println(lines)
+	// Output:
+	// <nil>
+	// [one two three]
 }

--- a/it/lines_test.go
+++ b/it/lines_test.go
@@ -70,6 +70,7 @@ func TestLinesYieldsFalseWithError(t *testing.T) {
 
 func ExampleLinesString() {
 	buffer := strings.NewReader("one\ntwo\nthree\n")
+
 	for line, err := range it.LinesString(buffer) {
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
**Please provide a brief description of the change.**

A common form of iteratoring with an `iter.Seq` will be pairs of values where the right side is an error (for exampling iterating over lines in an `io.Reader`. `CollectErr` is a helper that will collect the left values from the iterator and the right `error` values will be joined into a single error.

**Which issue does this change relate to?**

None.

**Contribution checklist.**

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies

**Additional context**

~~I've also added some helper functions to extend the power of this change. `op.Apply{Left/Right}` are to be used with `Map2` in order to apply a function to only left or right values. I'm considering `Filter{Left/Right}` also.~~
