### PR TITLE
Support FromSlice and FromMap helpers in itx

### DIFF
--- a/it/itx/chain_test.go
+++ b/it/itx/chain_test.go
@@ -4,20 +4,19 @@ import (
 	"fmt"
 	"iter"
 	"maps"
-	"slices"
 
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
 func ExampleIterator_Chain() {
-	numbers := itx.From(slices.Values([]int{1, 2})).Chain(slices.Values([]int{3, 4})).Collect()
+	numbers := itx.FromSlice([]int{1, 2}).Chain(itx.FromSlice([]int{3, 4})).Collect()
 
 	fmt.Println(numbers)
 	// Output: [1 2 3 4]
 }
 
 func ExampleIterator2_Chain() {
-	pairs := itx.From2(maps.All(map[string]int{"a": 1})).Chain(maps.All(map[string]int{"b": 2}))
+	pairs := itx.FromMap(map[string]int{"a": 1}).Chain(maps.All(map[string]int{"b": 2}))
 
 	fmt.Println(len(maps.Collect(iter.Seq2[string, int](pairs))))
 	// Output: 2

--- a/it/itx/channel_test.go
+++ b/it/itx/channel_test.go
@@ -2,7 +2,6 @@ package itx_test
 
 import (
 	"fmt"
-	"slices"
 
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
@@ -26,7 +25,7 @@ func ExampleFromChannel() {
 }
 
 func ExampleIterator_ToChannel() {
-	channel := itx.From(slices.Values([]int{1, 2, 3})).ToChannel()
+	channel := itx.FromSlice([]int{1, 2, 3}).ToChannel()
 
 	for number := range channel {
 		fmt.Println(number)

--- a/it/itx/cycle_test.go
+++ b/it/itx/cycle_test.go
@@ -2,23 +2,21 @@ package itx_test
 
 import (
 	"fmt"
-	"iter"
 	"maps"
-	"slices"
 
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
 func ExampleIterator_Cycle() {
-	numbers := itx.From(slices.Values([]int{1, 2})).Cycle().Take(5).Collect()
+	numbers := itx.FromSlice([]int{1, 2}).Cycle().Take(5).Collect()
 
 	fmt.Println(numbers)
 	// Output: [1 2 1 2 1]
 }
 
 func ExampleIterator2_Cycle() {
-	numbers := itx.Iterator2[int, string](maps.All(map[int]string{1: "one"})).Cycle().Take(5)
+	numbers := itx.FromMap(map[int]string{1: "one"}).Cycle().Take(5)
 
-	fmt.Println(maps.Collect(iter.Seq2[int, string](numbers)))
+	fmt.Println(maps.Collect(numbers.Seq()))
 	// Output: map[1:one]
 }

--- a/it/itx/drop_test.go
+++ b/it/itx/drop_test.go
@@ -3,13 +3,12 @@ package itx_test
 import (
 	"fmt"
 	"maps"
-	"slices"
 
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
 func ExampleIterator_Drop() {
-	for value := range itx.From(slices.Values([]int{1, 2, 3, 4, 5})).Drop(2) {
+	for value := range itx.FromSlice([]int{1, 2, 3, 4, 5}).Drop(2) {
 		fmt.Println(value)
 	}
 
@@ -20,7 +19,7 @@ func ExampleIterator_Drop() {
 }
 
 func ExampleIterator2_Drop() {
-	numbers := itx.From2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"})).Drop(1)
+	numbers := itx.FromMap(map[int]string{1: "one", 2: "two", 3: "three"}).Drop(1)
 
 	fmt.Println(len(maps.Collect(numbers.Seq())))
 	// Output: 2

--- a/it/itx/enumerate_test.go
+++ b/it/itx/enumerate_test.go
@@ -2,13 +2,12 @@ package itx_test
 
 import (
 	"fmt"
-	"slices"
 
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
 func ExampleIterator_Enumerate() {
-	for index, value := range itx.From(slices.Values([]int{1, 2, 3})).Enumerate() {
+	for index, value := range itx.FromSlice([]int{1, 2, 3}).Enumerate() {
 		fmt.Println(index, value)
 	}
 

--- a/it/itx/filter_test.go
+++ b/it/itx/filter_test.go
@@ -2,15 +2,13 @@ package itx_test
 
 import (
 	"fmt"
-	"maps"
-	"slices"
 
 	"github.com/BooleanCat/go-functional/v2/it/filter"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
 func ExampleIterator_Filter() {
-	for number := range itx.From(slices.Values([]int{1, 2, 3, 4, 5})).Filter(filter.IsEven) {
+	for number := range itx.FromSlice([]int{1, 2, 3, 4, 5}).Filter(filter.IsEven) {
 		fmt.Println(number)
 	}
 
@@ -20,7 +18,7 @@ func ExampleIterator_Filter() {
 }
 
 func ExampleIterator_Exclude() {
-	for number := range itx.From(slices.Values([]int{1, 2, 3, 4, 5})).Exclude(filter.IsEven) {
+	for number := range itx.FromSlice([]int{1, 2, 3, 4, 5}).Exclude(filter.IsEven) {
 		fmt.Println(number)
 	}
 
@@ -34,7 +32,7 @@ func ExampleIterator2_Filter() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 2: "two", 3: "three"}
 
-	for key, value := range itx.From2(maps.All(numbers)).Filter(isOne) {
+	for key, value := range itx.FromMap(numbers).Filter(isOne) {
 		fmt.Println(key, value)
 	}
 
@@ -45,7 +43,7 @@ func ExampleIterator2_Exclude() {
 	isOne := func(n int, _ string) bool { return n == 1 }
 	numbers := map[int]string{1: "one", 3: "three"}
 
-	for key, value := range itx.From2(maps.All(numbers)).Exclude(isOne) {
+	for key, value := range itx.FromMap(numbers).Exclude(isOne) {
 		fmt.Println(key, value)
 	}
 

--- a/it/itx/iter.go
+++ b/it/itx/iter.go
@@ -2,6 +2,7 @@ package itx
 
 import (
 	"iter"
+	"maps"
 	"slices"
 
 	"github.com/BooleanCat/go-functional/v2/it"
@@ -25,6 +26,16 @@ func From[V any](iterator func(func(V) bool)) Iterator[V] {
 // From2 converts an iterator in an [Iterator2] to support method chaining.
 func From2[V, W any](iterator func(func(V, W) bool)) Iterator2[V, W] {
 	return Iterator2[V, W](iterator)
+}
+
+// FromSlice converts a slice to an [Iterator].
+func FromSlice[V any](slice []V) Iterator[V] {
+	return Iterator[V](slices.Values(slice))
+}
+
+// FromMap converts a map to an [Iterator2].
+func FromMap[V comparable, W any](m map[V]W) Iterator2[V, W] {
+	return Iterator2[V, W](maps.All(m))
 }
 
 // Seq converts an [Iterator] to an [iter.Seq].

--- a/it/itx/iter_test.go
+++ b/it/itx/iter_test.go
@@ -14,17 +14,17 @@ func ExampleIterator_Seq() {
 }
 
 func ExampleIterator2_Seq() {
-	fmt.Println(maps.Collect(itx.From2(maps.All(map[int]int{1: 2})).Seq()))
+	fmt.Println(maps.Collect(itx.FromMap(map[int]int{1: 2}).Seq()))
 	// Output: map[1:2]
 }
 
 func ExampleIterator_Collect() {
-	fmt.Println(itx.From(slices.Values([]int{1, 2, 3})).Collect())
+	fmt.Println(itx.FromSlice([]int{1, 2, 3}).Collect())
 	// Output: [1 2 3]
 }
 
 func ExampleIterator_ForEach() {
-	itx.From(slices.Values([]int{1, 2, 3})).ForEach(func(number int) {
+	itx.FromSlice([]int{1, 2, 3}).ForEach(func(number int) {
 		fmt.Println(number)
 	})
 	// Output:
@@ -34,7 +34,7 @@ func ExampleIterator_ForEach() {
 }
 
 func ExampleIterator2_ForEach() {
-	itx.From(slices.Values([]int{1, 2, 3})).Enumerate().ForEach(func(index int, number int) {
+	itx.FromSlice([]int{1, 2, 3}).Enumerate().ForEach(func(index int, number int) {
 		fmt.Println(index, number)
 	})
 	// Output:
@@ -44,15 +44,36 @@ func ExampleIterator2_ForEach() {
 }
 
 func ExampleIterator_Find() {
-	fmt.Println(itx.From(slices.Values([]int{1, 2, 3})).Find(func(number int) bool {
+	fmt.Println(itx.FromSlice([]int{1, 2, 3}).Find(func(number int) bool {
 		return number == 2
 	}))
 	// Output: 2 true
 }
 
 func ExampleIterator2_Find() {
-	fmt.Println(itx.From(slices.Values([]int{1, 2, 3})).Enumerate().Find(func(index int, number int) bool {
+	fmt.Println(itx.FromSlice([]int{1, 2, 3}).Enumerate().Find(func(index int, number int) bool {
 		return index == 1
 	}))
 	// Output: 1 2 true
+}
+
+func ExampleFrom() {
+	fmt.Println(itx.From(slices.Values([]int{1, 2, 3})).Collect())
+	// Output: [1 2 3]
+}
+
+func ExampleFrom2() {
+	numbers := maps.All(map[int]string{1: "one"})
+	fmt.Println(maps.Collect(itx.From2(numbers).Seq()))
+	// Output: map[1:one]
+}
+
+func ExampleFromSlice() {
+	fmt.Println(itx.FromSlice([]int{1, 2, 3}).Collect())
+	// Output: [1 2 3]
+}
+
+func ExampleFromMap() {
+	fmt.Println(itx.FromMap(map[int]int{1: 2}).Right().Collect())
+	// Output: [2]
 }

--- a/it/itx/take_test.go
+++ b/it/itx/take_test.go
@@ -3,13 +3,12 @@ package itx_test
 import (
 	"fmt"
 	"maps"
-	"slices"
 
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
 func ExampleIterator_Take() {
-	for number := range itx.From(slices.Values([]int{1, 2, 3, 4, 5})).Take(3) {
+	for number := range itx.FromSlice([]int{1, 2, 3, 4, 5}).Take(3) {
 		fmt.Println(number)
 	}
 
@@ -20,7 +19,7 @@ func ExampleIterator_Take() {
 }
 
 func ExampleIterator2_Take() {
-	numbers := maps.Collect(itx.From2(maps.All(map[int]string{1: "one", 2: "two", 3: "three"})).Take(2).Seq())
+	numbers := maps.Collect(itx.FromMap(map[int]string{1: "one", 2: "two", 3: "three"}).Take(2).Seq())
 
 	fmt.Println(len(numbers))
 	// Output: 2

--- a/it/itx/zip_test.go
+++ b/it/itx/zip_test.go
@@ -2,7 +2,6 @@ package itx_test
 
 import (
 	"fmt"
-	"maps"
 	"strings"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func ExampleIterator2_Unzip() {
-	keys, values := itx.From2(maps.All(map[int]string{1: "one"})).Unzip()
+	keys, values := itx.FromMap(map[int]string{1: "one"}).Unzip()
 
 	for key := range keys {
 		fmt.Println(key)
@@ -27,7 +26,7 @@ func ExampleIterator2_Unzip() {
 }
 
 func TestUnzipMethod(t *testing.T) {
-	keys, values := itx.From2(maps.All(map[int]string{1: "one"})).Unzip()
+	keys, values := itx.FromMap(map[int]string{1: "one"}).Unzip()
 
 	assert.SliceEqual(t, keys.Collect(), []int{1})
 	assert.SliceEqual(t, values.Collect(), []string{"one"})
@@ -41,7 +40,7 @@ func ExampleIterator2_Left() {
 }
 
 func ExampleIterator2_Right() {
-	for value := range itx.From2(maps.All(map[int]string{1: "one"})).Right() {
+	for value := range itx.FromMap(map[int]string{1: "one"}).Right() {
 		fmt.Println(value)
 	}
 	// Output: one


### PR DESCRIPTION
**Please provide a brief description of the change.**

Using `itx.From(slices.Values(slice))` will be a fairly common pattern so this is to make that a bit less verbose with `itx.FromSlice(slice)` (and same for `FromMap`).

**Which issue does this change relate to?**

None.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies

**Additional context**

N/A.
