### PR TITLE
Add MapError iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ for line, err := range it.LinesString(buffer) {
 > As with [bufio.Scanner](https://pkg.go.dev/bufio#Scanner), there is a maximum line length per line
 > of 65536 characters.
 
-### Map & Transform
+<h3 id="map">Map & Transform</h3
 
 Map yields values from an iterator that have had the provided function applied to each value.
 Transform serves the same purpose but contrains the return type to the type of the iterator's values
@@ -586,6 +586,38 @@ itx.FromMap(map[int]int{1: 2}).Transform(doubleBoth)
 >
 > ```go
 > itx.From(it.Map(slices.Values([]int{1, 2, 3}), double)).Collect()
+> ```
+
+### MapError & TransformError
+
+`MapError` and `TransformError` behave like [Map and Transform](#map) except that they accept a
+function that may return an error.
+
+```go
+double := func(n int, err error) int { return n * 2, nil }
+
+it.MapError(slices.Values([]int{1, 2, 3}), double)
+
+// Limited chainable flavour of MapError
+itx.FromSlice([]int{1, 2, 3}).TransformError(double)
+```
+
+<!-- prettier-ignore -->
+> [!NOTE]
+> The `itx` package does not contain `MapError` due to limitations with Go's type system. Instead a
+> limited from of `MapError` called `TransformError` is provided where the type returned from
+> operations is the same as a type of the iterator's values.
+>
+> A chainable MapError will be added should Go's type system ever support new generic type
+> parameters on methods.
+
+<!-- prettier-ignore -->
+> [!TIP]
+> If you wish to chain operations on `MapError`, you can do so by first converting it to an
+> `itx.Iterator2` like so:
+>
+> ```go
+> itx.From2(it.MapError(slices.Values([]int{1, 2, 3}), double)).Collect()
 > ```
 
 ### NaturalNumbers

--- a/it/itx/map.go
+++ b/it/itx/map.go
@@ -19,3 +19,13 @@ func (iterator Iterator[V]) Transform(f func(V) V) Iterator[V] {
 func (iterator Iterator2[V, W]) Transform(f func(V, W) (V, W)) Iterator2[V, W] {
 	return Iterator2[V, W](it.Map2(iterator, f))
 }
+
+// TransformError is a convenience method for chaining [it.MapError] on
+// [Iterator]s where the provided functions argument type is the same as its
+// return type.
+//
+// This is a limited version of [it.MapError] due to a limitation on Go's type
+// system whereby new generic type parameters cannot be defined on methods.
+func (iterator Iterator[V]) TransformError(f func(V) (V, error)) Iterator2[V, error] {
+	return Iterator2[V, error](it.MapError(iterator, f))
+}

--- a/it/itx/map_test.go
+++ b/it/itx/map_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 
+	"github.com/BooleanCat/go-functional/v2/it"
 	"github.com/BooleanCat/go-functional/v2/it/itx"
 )
 
@@ -21,4 +22,11 @@ func ExampleIterator2_Transform() {
 
 	fmt.Println(maps.Collect(itx.FromMap(map[int]int{1: 2}).Transform(addOne).Seq()))
 	// Output: map[2:3]
+}
+
+func ExampleIterator_TransformError() {
+	fmt.Println(it.TryCollect(itx.FromSlice([]int{0, 1, 2}).TransformError(func(v int) (int, error) {
+		return v + 1, nil
+	})))
+	// Output: [1 2 3] <nil>
 }

--- a/it/map.go
+++ b/it/map.go
@@ -25,3 +25,21 @@ func Map2[V, W, X, Y any](delegate func(func(V, W) bool), f func(V, W) (X, Y)) i
 		}
 	}
 }
+
+// MapError yields values from an iterator that have had the provided function
+// applied to each value where the function can return an error.
+func MapError[V, W any](delegate func(func(V) bool), f func(V) (W, error)) iter.Seq2[W, error] {
+	return func(yield func(W, error) bool) {
+		for value := range delegate {
+			if result, err := f(value); err != nil {
+				if !yield(result, err) {
+					return
+				}
+			} else {
+				if !yield(result, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/it/map_test.go
+++ b/it/map_test.go
@@ -1,6 +1,7 @@
 package it_test
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -78,6 +79,54 @@ func TestMap2YieldFalse(t *testing.T) {
 	})
 
 	numbers(func(v, w int) bool {
+		return false
+	})
+}
+
+func ExampleMapError() {
+	double := func(n int) (int, error) { return n * 2, nil }
+
+	numbers, err := it.TryCollect(it.MapError(slices.Values([]int{1, 2, 3}), double))
+	if err == nil {
+		fmt.Println(numbers)
+	}
+
+	// Output: [2 4 6]
+}
+
+func TestMapErrorYieldsFalse(t *testing.T) {
+	t.Parallel()
+
+	numbers := it.MapError(slices.Values([]int{1, 2, 3}), func(a int) (int, error) {
+		return a + 1, nil
+	})
+
+	numbers(func(int, error) bool {
+		return false
+	})
+}
+
+func TestMapErrorError(t *testing.T) {
+	t.Parallel()
+
+	numbers, errs := it.Collect2(it.MapError(slices.Values([]int{1, 2}), func(a int) (int, error) {
+		return 0, errors.New("nope")
+	}))
+
+	assert.SliceEqual(t, []int{0, 0}, numbers)
+	assert.Equal(t, len(errs), 2)
+	assert.Equal(t, errs[0].Error(), "nope")
+	assert.Equal(t, errs[1].Error(), "nope")
+}
+
+func TestMapErrorErrorYieldsFalse(t *testing.T) {
+	t.Parallel()
+
+	numbers := it.MapError(slices.Values([]int{1, 2}), func(a int) (int, error) {
+		return 0, errors.New("nope")
+	})
+
+	numbers(func(int, error) bool {
 		return false
 	})
 }


### PR DESCRIPTION
**Please provide a brief description of the change.**

Support map operations that can return an error.

**Which issue does this change relate to?**

N/A.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies
