### PR TITLE
Test in CI with go 1.23

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0-rc.2
+          go-version: "1.23"
           cache: false
       - run: make check
         env: { SKIP_LINT: true }
@@ -28,6 +28,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0-rc.2
+          go-version: "1.23"
           cache: false
       - run: make test


### PR DESCRIPTION
**Please provide a brief description of the change.**

Go 1.23 is GA so stop testing with the release candidate.

**Which issue does this change relate to?**

N/A.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies

**Additional context**

None.
