### PR TITLE
Add filter unique functionality

### DIFF
--- a/it/filter_unique.go
+++ b/it/filter_unique.go
@@ -2,7 +2,7 @@ package it
 
 import "iter"
 
-// FilterUnique Yields all the unique values in an iterator.
+// FilterUnique yields all the unique values from an iterator.
 //
 // Note: All unique values seen from an iterator are stored in memory.
 func FilterUnique[V comparable](iterator func(func(V) bool)) iter.Seq[V] {

--- a/it/filter_unique.go
+++ b/it/filter_unique.go
@@ -1,0 +1,22 @@
+package it
+
+import "iter"
+
+// FilterUnique Yields all the unique values in an iterator.
+//
+// Note: All unique values seen from an iterator are stored in memory.
+func FilterUnique[V comparable](iterator func(func(V) bool)) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		seen := make(map[V]struct{})
+		for value := range iterator {
+			if _, ok := seen[value]; ok {
+				continue
+			}
+
+			seen[value] = struct{}{}
+			if !yield(value) {
+				return
+			}
+		}
+	}
+}

--- a/it/filter_unique_test.go
+++ b/it/filter_unique_test.go
@@ -1,0 +1,55 @@
+package it_test
+
+import (
+	"fmt"
+	"github.com/BooleanCat/go-functional/v2/internal/assert"
+	"github.com/BooleanCat/go-functional/v2/it"
+	"slices"
+	"testing"
+)
+
+func ExampleFilterUnique() {
+	for number := range it.FilterUnique(slices.Values([]int{1, 2, 2, 3, 3, 3, 4, 5})) {
+		fmt.Println(number)
+	}
+
+	// Output:
+	// 1
+	// 2
+	// 3
+	// 4
+	// 5
+}
+
+func TestFilterUniqueEmpty(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty[int](t, slices.Collect(it.Chain[int]()))
+}
+
+func TestFilterUniqueYieldFalse(t *testing.T) {
+	t.Parallel()
+
+	iterator := it.FilterUnique(slices.Values([]int{100, 200, 300}))
+
+	var value int
+	iterator(func(v int) bool {
+		value = v
+		return false
+	})
+	assert.Equal(t, 100, value)
+}
+
+func TestFilterUniqueWithNoDuplicates(t *testing.T) {
+	t.Parallel()
+
+	numbers := slices.Collect(it.FilterUnique(slices.Values([]int{1, 2, 3})))
+	assert.SliceEqual(t, []int{1, 2, 3}, numbers)
+}
+
+func TestFilterUniqueWithDuplicates(t *testing.T) {
+	t.Parallel()
+
+	strings := slices.Collect(it.FilterUnique(slices.Values([]string{"hello", "world", "hello", "world", "hello"})))
+	assert.SliceEqual(t, []string{"hello", "world"}, strings)
+}


### PR DESCRIPTION
Address the issue raised in #146 

Adds a Filter unique functionality to only yield unique values. 

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies

**Additional context**

_Add any other context about the problem here._
