### PR TITLE
Provide ref and deref ops for Map

### DIFF
--- a/it/op/op.go
+++ b/it/op/op.go
@@ -4,3 +4,13 @@ package op
 func Add[V ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~string | ~float32 | ~float64](a, b V) V {
 	return a + b
 }
+
+// Ref returns a reference to the provided value.
+func Ref[V any](v V) *V {
+	return &v
+}
+
+// Deref returns the value pointed to by the provided pointer.
+func Deref[V any](v *V) V {
+	return *v
+}

--- a/it/op/op_test.go
+++ b/it/op/op_test.go
@@ -17,3 +17,20 @@ func ExampleAdd_string() {
 	fmt.Println(it.Fold(slices.Values([]string{"a", "b", "c"}), op.Add, ""))
 	// Output: abc
 }
+
+func ExampleRef() {
+	refs := slices.Collect(it.Map(slices.Values([]int{5, 6, 7}), op.Ref))
+	fmt.Println(*refs[0], *refs[1], *refs[2])
+	// Output: 5 6 7
+}
+
+func ExampleDeref() {
+	intRef := func(a int) *int {
+		return &a
+	}
+
+	values := slices.Values([]*int{intRef(4), intRef(5), intRef(6)})
+
+	fmt.Println(slices.Collect(it.Map(values, op.Deref)))
+	// Output: [4 5 6]
+}


### PR DESCRIPTION
**Please provide a brief description of the change.**

Other packages commonly use pointers as optionals for values. These helpers can help to manage those values cleanly with `it.Map`.

**Which issue does this change relate to?**

None.

**Contribution checklist.**

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies

**Additional context**

None.
