### PR TITLE
fix documentation for `All`, which actually returns false

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ library chainable.
 Iteration will terminate early if `false` is encountered. Empty iterators will return `true`.
 
 ```go
-it.All(slices.Values([]bool{true, false, true}))  // true
+it.All(slices.Values([]bool{true, false, true}))  // false
 ```
 
 `Any` will return `true` if any value yielded by an iterator is `true`, or `false` otherwise.


### PR DESCRIPTION
**Please provide a brief description of the change.**

The documentation for `All` in the README was wrong - the correct return value is `false`.

**Which issue does this change relate to?**

n/a

**Contribution checklist.**

_Replace the space in each box with "X" to check it off._

- [x] I have read and understood the CONTRIBUTING guidelines
- [x] All commits in my PR conform to the commit hygiene section
- [x] I have added relevant tests
- [x] I have not added any dependencies

**Additional context**

n/a