### PR TITLE
Use golangci-lint v2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
           cache: false
       - run: make check
         env: { SKIP_LINT: true }
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with: { version: "latest" }
       - run: make cov
       - uses: codecov/codecov-action@v5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,41 +1,58 @@
-run: { timeout: 3m }
-
-linters-settings:
-  cyclop:
-    max-complexity: 15
-    package-average: 0.5
-    skip-tests: false
-
-  govet: { enable-all: true }
-
-  misspell: { locale: US }
-
-  depguard:
-    rules:
-      main: { allow: ["$gostd", "github.com/BooleanCat/go-functional/v2"] }
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
     - asasalint
     - asciicheck
     - bidichk
     - decorder
     - depguard
     - durationcheck
+    - errcheck
     - errchkjson
     - errorlint
     - exhaustive
     - gochecknoglobals
     - gocritic
-    - gosec
-    - nilerr
-    - gofmt
     - gocyclo
+    - gosec
+    - govet
+    - ineffassign
     - misspell
+    - nilerr
+    - staticcheck
+    - unused
+  settings:
+    cyclop:
+      max-complexity: 15
+      package-average: 0.5
+    depguard:
+      rules:
+        main:
+          allow:
+            - $gostd
+            - github.com/BooleanCat/go-functional/v2
+    govet:
+      enable-all: true
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
**Please provide a brief description of the change.**

Use and support the latest version of `golangci-lint`. The configuration file was migrated used `golangci-lint migrate`.

**Which issue does this change relate to?**

None.

**Contribution checklist.**

- [X] I have read and understood the CONTRIBUTING guidelines
- [X] All commits in my PR conform to the commit hygiene section
- [X] I have added relevant tests
- [X] I have not added any dependencies

**Additional context**

N/A.
